### PR TITLE
feat: recover 6 commits from scottidler/claude-permit + full README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "terminal_size",
  "which",
 ]
 
@@ -795,6 +796,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"
+terminal_size = "0.4.4"
 which = "8.0.2"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # claude-permit
-Rust cli to allow claude to touch things
+
+Rust CLI to allow Claude to touch things.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/tatari-tv/claude-permit/main/install.sh | bash
+```
+
+Installs to `~/.local/bin` by default. Override with `INSTALL_DIR`:
+
+```bash
+INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/tatari-tv/claude-permit/main/install.sh | bash
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-permit
 
-Rust CLI to allow Claude to touch things.
+Rust CLI that logs every Claude Code tool invocation, classifies permission rules by risk tier, and produces actionable recommendations to tighten your security posture.
 
 ## Install
 
@@ -13,3 +13,259 @@ Installs to `~/.local/bin` by default. Override with `INSTALL_DIR`:
 ```bash
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/tatari-tv/claude-permit/main/install.sh | bash
 ```
+
+### From Source
+
+```bash
+cargo install --git https://github.com/tatari-tv/claude-permit
+```
+
+---
+
+## Problem
+
+Claude Code accumulates permission rules over time through one-off approvals during sessions. These rules live in `settings.json` and `settings.local.json` with no built-in way to review, prune, or promote them. After a few weeks of use, you end up with hundreds of rules - some dangerously broad, some stale, some duplicated - and no feedback loop between your permission decisions and your permission policy.
+
+You can't answer basic questions: Which rules are never used? Which one-off approvals keep recurring and should be permanent? Which rules are dangerously broad? Are any rules violating safety policies (e.g., allowing `rm -rf` instead of a safe alternative)?
+
+---
+
+## Setup
+
+### 1. Register the hook
+
+```bash
+claude-permit install --yes
+```
+
+This adds `claude-permit log` to the `PreToolUse` hooks in `~/.claude/settings.json`. Or add it manually:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "claude-permit log" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 2. Verify
+
+```bash
+claude-permit check
+```
+
+Confirms the SQLite database is writable, the hook is registered, and the binary is in PATH.
+
+### 3. Use Claude Code normally
+
+Every tool invocation is silently logged to a local SQLite database (`~/.local/share/claude-permit/events.db`) with timestamp, session ID, tool name, normalized input, and risk tier. The hook completes in under 50ms and never blocks your session.
+
+---
+
+## Commands
+
+### audit
+
+Reads `settings.json` and `settings.local.json`, classifies every rule by risk tier, checks against the deny list, and outputs a recommendation for each rule.
+
+```bash
+# Show all rules
+claude-permit audit
+
+# Filter by pattern (exact -> prefix -> substring cascade)
+claude-permit audit docker
+claude-permit audit git cargo
+claude-permit audit "Bash(git status:*)"
+
+# Filter by risk tier (cannot combine with --apply)
+claude-permit audit --risk dangerous
+claude-permit audit --risk moderate
+
+# Apply all actionable recommendations and write changes
+claude-permit audit --apply
+
+# Apply specific actions only
+claude-permit audit --apply promote
+claude-permit audit --apply remove dupe
+claude-permit audit --apply promote remove deny dupe
+
+# Combine pattern filter with apply
+claude-permit audit docker --apply
+claude-permit audit git --apply remove
+
+# Change output format
+claude-permit audit --format json
+claude-permit audit --format markdown
+```
+
+**Pattern filtering** uses a cascading match: tries exact first, then prefix, then substring. Returns the first non-empty result set. No patterns returns everything.
+
+`--apply` actions:
+
+| Action | What it does |
+| --- | --- |
+| `promote` | Moves safe rules from local to global settings |
+| `remove` | Deletes dangerous rules from local settings |
+| `deny` | Removes deny-list violations from allow lists |
+| `dupe` | Removes rules covered by a broader rule |
+
+`--apply` with no action words applies all four. `--apply` and `--risk` are mutually exclusive - use pattern filtering to narrow scope before applying.
+
+**Recommendation column values:**
+
+| Value | Meaning |
+| --- | --- |
+| `keep` | Rule is fine where it is |
+| `promote` | Safe rule in local - move to global |
+| `narrow` | Pattern is too broad - tighten it manually |
+| `remove` | Dangerous rule - delete it |
+| `deny` | Matches a permanent deny pattern - remove from allow list |
+| `dupe` | Covered by a broader rule - redundant |
+
+---
+
+### suggest
+
+Queries the event database for patterns you've approved repeatedly across multiple sessions and recommends promoting them to permanent allow rules.
+
+```bash
+# Show all suggestions
+claude-permit suggest
+
+# Filter by pattern
+claude-permit suggest git
+claude-permit suggest Bash
+
+# Tune thresholds
+claude-permit suggest --threshold 5 --sessions 3
+
+# Change output format
+claude-permit suggest --format json
+claude-permit suggest --format markdown
+```
+
+Default thresholds: 3+ observations, 2+ distinct sessions. Only tools that aren't internal Claude mechanics (TaskCreate, SendMessage, Agent, etc.) are surfaced.
+
+---
+
+### report
+
+Session summary of permission activity - event counts by risk tier, top tools used, and a list of any dangerous events.
+
+```bash
+claude-permit report              # latest session
+claude-permit report --session <id>
+claude-permit report --format json
+```
+
+---
+
+### clean
+
+Prune old events from the database.
+
+```bash
+claude-permit clean                    # delete events older than 90 days
+claude-permit clean --older-than 30
+claude-permit clean --dry-run          # preview without deleting
+```
+
+---
+
+### check
+
+Verify hook installation and database connectivity. Exits non-zero if anything is misconfigured.
+
+```bash
+claude-permit check
+```
+
+---
+
+### install
+
+Add the PreToolUse hook to `~/.claude/settings.json`. Dry-run by default.
+
+```bash
+claude-permit install          # preview - shows what would be added
+claude-permit install --yes    # write changes
+```
+
+Skips silently if the hook is already registered.
+
+---
+
+## Risk Tiers
+
+| Tier | Examples |
+| --- | --- |
+| **Safe** | `Bash(git status:*)`, `Bash(ls:*)`, `Read(**/*.rs)`, `WebSearch` |
+| **Moderate** | `Bash(git push:*)`, `Bash(cargo:*)`, `Edit(**/*.rs)`, `Read(**)` |
+| **Dangerous** | `Bash(sudo:*)`, `Bash(rm -rf:*)`, `Edit(**)`, `Write(**)` |
+
+**Notes:**
+
+- `Read(**)` (bare or wildcard) is **Moderate** - carte blanche filesystem read access
+- `Read(**/*.rs)` with a specific path pattern is **Safe**
+- `Edit(**)` and `Write(**)` are **Dangerous** - unrestricted write access
+
+### Permanent Deny Patterns
+
+These are blocked at hook time (when `enforce-deny: true`) and flagged in audit regardless:
+
+- `git tag -d` - local tag deletion
+- `git push * :refs/tags/` - remote tag deletion via refspec
+- `git push * --delete * tag` - remote tag deletion via `--delete`
+- `rm -rf` and `rm -r ` - recursive removal (use `rkvr rmrf` instead)
+- `cd && ` - compound cd with `&&`
+
+### Automatic Dangerous Rule Detection
+
+The following patterns are classified **Dangerous** regardless of command and flagged for removal:
+
+- **Environment variable assignments** - `GH_TOKEN="..." gh pr view`, `GIT_SSH_COMMAND="..." git push` - one-time invocations that shouldn't be permanent allow rules
+- `git -C <path>` - path-locked git operations specific to a single invocation context
+- `bash -c` - arbitrary shell escapes
+
+Clean these up with `claude-permit audit --apply remove`.
+
+---
+
+## Configuration
+
+`~/.config/claude-permit/claude-permit.yml`:
+
+```yaml
+suggest-threshold: 3      # min observations to trigger a suggestion
+suggest-sessions: 2       # min distinct sessions
+clean-older-than: 90      # days before cleanup eligibility
+enforce-deny: true        # block dangerous patterns at hook level (not just audit)
+pager: less -R            # pager command (omit to disable paging)
+# extra-deny-patterns:
+#   - "shutdown"
+#   - "reboot"
+# risk-overrides:
+#   "cargo build": "safe"
+```
+
+The pager activates only when output exceeds terminal height. Short results print directly.
+
+With `enforce-deny: true`, the hook blocks dangerous commands at invocation time and returns an error to Claude before the command runs.
+
+---
+
+## Tips
+
+- **Start with audit now** - Run `claude-permit audit` before enabling the hook. It reads your existing settings files and will surface surprises immediately.
+- **Filter before applying** - Use pattern args to narrow scope: `claude-permit audit docker --apply` only touches docker rules.
+- `audit` is your preview - Running `audit` without `--apply` is the dry run. What you see is exactly what `--apply` will act on.
+- **Promote recurring approvals** - If `suggest` keeps recommending the same patterns, promote them. Fewer prompts, no loss of security.
+- **Dupe cleanup is safe** - `--apply dupe` removes rules already covered by a broader rule. It cannot break anything.
+- **The hook is non-blocking** - It outputs passthrough JSON and completes in under 50ms. It never slows down your Claude Code sessions.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="tatari-tv/claude-permit"
+BIN_NAME="claude-permit"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+  linux)
+    case "$ARCH" in
+      x86_64)  SUFFIX="linux-amd64" ;;
+      aarch64) SUFFIX="linux-arm64" ;;
+      *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  darwin)
+    case "$ARCH" in
+      x86_64) SUFFIX="macos-x86_64" ;;
+      arm64)  SUFFIX="macos-arm64" ;;
+      *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+  | grep '"tag_name"' \
+  | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+if [ -z "$LATEST" ]; then
+  echo "Failed to determine latest release" >&2
+  exit 1
+fi
+
+TARBALL="${BIN_NAME}-${LATEST}-${SUFFIX}.tar.gz"
+URL="https://github.com/$REPO/releases/download/$LATEST/$TARBALL"
+
+echo "Installing $BIN_NAME $LATEST ($SUFFIX) to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "$TMP/$TARBALL"
+tar -xzf "$TMP/$TARBALL" -C "$TMP"
+install -m 755 "$TMP/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
+
+echo "Installed: $INSTALL_DIR/$BIN_NAME"
+
+if ! echo ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
+  echo "Note: add $INSTALL_DIR to your PATH"
+  echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,9 +32,14 @@ pub enum Command {
         #[arg(long, default_value = "table")]
         format: String,
 
-        /// Filter by risk tier: safe, moderate, dangerous
-        #[arg(long)]
+        /// Filter by risk tier: safe, moderate, dangerous (cannot be combined with --apply)
+        #[arg(long, conflicts_with = "apply")]
         risk: Option<String>,
+
+        /// Apply recommendations and write changes. Optionally specify actions:
+        /// promote, remove, deny, dupe (default: all). Cannot be combined with --risk.
+        #[arg(long, value_name = "ACTION", num_args = 0.., conflicts_with = "risk")]
+        apply: Option<Vec<String>>,
 
         /// Rule patterns to filter output (exact, prefix, or substring match)
         #[arg(value_name = "PATTERN")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,10 @@ pub enum Command {
         /// Filter by risk tier: safe, moderate, dangerous
         #[arg(long)]
         risk: Option<String>,
+
+        /// Rule patterns to filter output (exact, prefix, or substring match)
+        #[arg(value_name = "PATTERN")]
+        patterns: Vec<String>,
     },
 
     /// Suggest promotions based on usage patterns
@@ -50,6 +54,10 @@ pub enum Command {
         /// Output format: table, json, markdown
         #[arg(long, default_value = "table")]
         format: String,
+
+        /// Rule patterns to filter output (exact, prefix, or substring match)
+        #[arg(value_name = "PATTERN")]
+        patterns: Vec<String>,
     },
 
     /// Session summary of permission activity

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -67,16 +67,17 @@ pub fn run_apply(
 
     // Create backups
     if backup {
-        let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
-        let global_bak = format!("{}.bak.{ts}", settings_path.display());
-        let local_bak = format!("{}.bak.{ts}", settings_local_path.display());
-
-        std::fs::write(&global_bak, &global_content).context("Failed to create settings.json backup")?;
-        println!("Backup: {global_bak}");
-
+        let mut args = vec![settings_path.to_str().expect("valid path")];
         if settings_local_path.exists() {
-            std::fs::write(&local_bak, &local_content).context("Failed to create settings.local.json backup")?;
-            println!("Backup: {local_bak}");
+            args.push(settings_local_path.to_str().expect("valid path"));
+        }
+        let status = std::process::Command::new("rkvr")
+            .arg("bkup")
+            .args(&args)
+            .status()
+            .context("Failed to run rkvr bkup")?;
+        if !status.success() {
+            eyre::bail!("rkvr bkup failed");
         }
     }
 
@@ -142,6 +143,9 @@ fn build_summary(entries: &[AuditEntry], filter: &ApplyFilter) -> ApplySummary {
     let mut narrow_skipped = 0;
 
     for entry in entries {
+        if entry.list != "allow" {
+            continue;
+        }
         match entry.recommendation {
             Recommendation::Promote if filter.promote => {
                 promoted.push(entry.rule.clone());
@@ -372,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn backup_creates_files() {
+    fn backup_runs_without_error() {
         let dir = TempDir::new().expect("temp");
         let (gp, lp) = write_settings(
             dir.path(),
@@ -385,15 +389,8 @@ mod tests {
             remove: true,
             deny: false,
         };
+        // rkvr must be available in PATH; this is an integration smoke test
         run_apply(&gp, &lp, &filter, true, true).expect("apply");
-
-        // Check that backup files were created
-        let entries: Vec<_> = std::fs::read_dir(dir.path())
-            .expect("readdir")
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().contains(".bak."))
-            .collect();
-        assert!(!entries.is_empty(), "expected at least one backup file");
     }
 
     #[test]
@@ -441,6 +438,28 @@ mod tests {
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
         let local_allow = local["permissions"]["allow"].as_array().expect("array");
         assert_eq!(local_allow.len(), 2);
+    }
+
+    #[test]
+    fn deny_list_rules_not_acted_on() {
+        let dir = TempDir::new().expect("temp");
+        let (gp, lp) = write_settings(
+            dir.path(),
+            r#"{"permissions":{"allow":[],"deny":["Bash(git tag -d *)","Bash(rm -rf:*)"]}}"#,
+            r#"{"permissions":{"allow":[]}}"#,
+        );
+
+        let filter = ApplyFilter {
+            promote: true,
+            remove: true,
+            deny: true,
+        };
+        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+
+        // Deny-list rules should not be touched - they're already denied
+        let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
+        let deny = global["permissions"]["deny"].as_array().expect("array");
+        assert_eq!(deny.len(), 2, "deny list should be unchanged");
     }
 
     #[test]

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1,5 +1,5 @@
 use colored::*;
-use eyre::{Context, Result};
+use eyre::{Context, Result, bail};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::Path;
@@ -12,6 +12,34 @@ pub struct ApplyFilter {
     pub promote: bool,
     pub remove: bool,
     pub deny: bool,
+    pub dupe: bool,
+}
+
+impl ApplyFilter {
+    /// All actionable recommendations.
+    pub fn all() -> Self {
+        Self { promote: true, remove: true, deny: true, dupe: true }
+    }
+}
+
+/// Parse action words from CLI into an ApplyFilter.
+/// Empty slice means all actionable.
+pub fn parse_apply_filter(actions: &[String]) -> Result<ApplyFilter> {
+    if actions.is_empty() {
+        return Ok(ApplyFilter::all());
+    }
+    for action in actions {
+        match action.as_str() {
+            "promote" | "remove" | "deny" | "dupe" => {}
+            other => bail!("Unknown apply action '{}'. Valid: promote, remove, deny, dupe", other),
+        }
+    }
+    Ok(ApplyFilter {
+        promote: actions.iter().any(|a| a == "promote"),
+        remove: actions.iter().any(|a| a == "remove"),
+        deny: actions.iter().any(|a| a == "deny"),
+        dupe: actions.iter().any(|a| a == "dupe"),
+    })
 }
 
 /// Summary of what was (or would be) applied.
@@ -19,24 +47,21 @@ pub struct ApplySummary {
     pub promoted: Vec<String>,
     pub removed: Vec<String>,
     pub denied: Vec<String>,
+    pub duped: Vec<(String, String)>, // (rule, source)
     pub narrow_skipped: usize,
 }
 
-/// Run the apply command.
-pub fn run_apply(
+/// Apply recommendations from already-audited entries.
+pub fn apply_entries(
+    entries: &[AuditEntry],
+    filter: &ApplyFilter,
     settings_path: &Path,
     settings_local_path: &Path,
-    filter: &ApplyFilter,
-    write: bool,
     backup: bool,
+    write: bool,
 ) -> Result<()> {
-    // Run audit to get recommendations
-    let entries = audit(settings_path, settings_local_path, &[], None)?;
-
-    // Partition entries by recommendation
-    let summary = build_summary(&entries, filter);
-
-    let total = summary.promoted.len() + summary.removed.len() + summary.denied.len();
+    let summary = build_summary(entries, filter);
+    let total = summary.promoted.len() + summary.removed.len() + summary.denied.len() + summary.duped.len();
 
     if total == 0 {
         println!("No actionable recommendations match the selected filters.");
@@ -46,15 +71,13 @@ pub fn run_apply(
         return Ok(());
     }
 
-    // Display what will happen
     print_plan(&summary, write);
 
     if !write {
-        println!("\n{}", "Pass --yes to apply these changes.".yellow().bold());
+        println!("\n{}", "Pass --apply to write these changes.".yellow().bold());
         return Ok(());
     }
 
-    // Load raw JSON values
     let global_content = std::fs::read_to_string(settings_path).context("Failed to read settings.json")?;
     let local_content = if settings_local_path.exists() {
         std::fs::read_to_string(settings_local_path).context("Failed to read settings.local.json")?
@@ -65,7 +88,6 @@ pub fn run_apply(
     let mut global: Value = serde_json::from_str(&global_content).context("Failed to parse settings.json")?;
     let mut local: Value = serde_json::from_str(&local_content).context("Failed to parse settings.local.json")?;
 
-    // Create backups
     if backup {
         let mut args = vec![settings_path.to_str().expect("valid path")];
         if settings_local_path.exists() {
@@ -77,21 +99,18 @@ pub fn run_apply(
             .status()
             .context("Failed to run rkvr bkup")?;
         if !status.success() {
-            eyre::bail!("rkvr bkup failed");
+            bail!("rkvr bkup failed");
         }
     }
 
-    // Apply operations
     let global_allow = get_allow_array(&mut global);
     let local_allow = get_allow_array(&mut local);
 
-    // Build a set of what's already in global allow for dedup
     let global_existing: HashSet<String> = global_allow
         .iter()
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
         .collect();
 
-    // Promote: add to global (if not already there), remove from local
     for rule in &summary.promoted {
         if !global_existing.contains(rule) {
             global_allow.push(Value::String(rule.clone()));
@@ -99,18 +118,23 @@ pub fn run_apply(
         remove_from_array(local_allow, rule);
     }
 
-    // Remove: delete from local allow
     for rule in &summary.removed {
         remove_from_array(local_allow, rule);
     }
 
-    // Deny: remove from whichever allow list contains it
     for rule in &summary.denied {
         remove_from_array(global_allow, rule);
         remove_from_array(local_allow, rule);
     }
 
-    // Write back
+    for (rule, source) in &summary.duped {
+        if source == "global" {
+            remove_from_array(global_allow, rule);
+        } else {
+            remove_from_array(local_allow, rule);
+        }
+    }
+
     let global_out = serde_json::to_string_pretty(&global)?;
     let local_out = serde_json::to_string_pretty(&local)?;
 
@@ -119,11 +143,12 @@ pub fn run_apply(
 
     println!();
     println!(
-        "{} Applied {} promote, {} remove, {} deny operations.",
+        "{} Applied {} promote, {} remove, {} deny, {} dupe.",
         "Done.".green().bold(),
         summary.promoted.len(),
         summary.removed.len(),
         summary.denied.len(),
+        summary.duped.len(),
     );
 
     if !summary.denied.is_empty() {
@@ -136,10 +161,23 @@ pub fn run_apply(
     Ok(())
 }
 
+/// Convenience wrapper used by tests: re-audits then applies.
+pub fn run_apply(
+    settings_path: &Path,
+    settings_local_path: &Path,
+    filter: &ApplyFilter,
+    write: bool,
+    backup: bool,
+) -> Result<()> {
+    let entries = audit(settings_path, settings_local_path, &[], None)?;
+    apply_entries(&entries, filter, settings_path, settings_local_path, backup, write)
+}
+
 fn build_summary(entries: &[AuditEntry], filter: &ApplyFilter) -> ApplySummary {
     let mut promoted = Vec::new();
     let mut removed = Vec::new();
     let mut denied = Vec::new();
+    let mut duped = Vec::new();
     let mut narrow_skipped = 0;
 
     for entry in entries {
@@ -156,6 +194,9 @@ fn build_summary(entries: &[AuditEntry], filter: &ApplyFilter) -> ApplySummary {
             Recommendation::Deny if filter.deny => {
                 denied.push(entry.rule.clone());
             }
+            Recommendation::Dupe if filter.dupe => {
+                duped.push((entry.rule.clone(), entry.source.clone()));
+            }
             Recommendation::Narrow => {
                 narrow_skipped += 1;
             }
@@ -163,49 +204,43 @@ fn build_summary(entries: &[AuditEntry], filter: &ApplyFilter) -> ApplySummary {
         }
     }
 
-    ApplySummary {
-        promoted,
-        removed,
-        denied,
-        narrow_skipped,
-    }
+    ApplySummary { promoted, removed, denied, duped, narrow_skipped }
 }
 
 fn print_plan(summary: &ApplySummary, write: bool) {
     let verb = if write { "Applying" } else { "Would apply" };
     println!(
-        "{} {} promote, {} remove, {} deny operations:",
+        "{} {} promote, {} remove, {} deny, {} dupe:",
         verb,
         summary.promoted.len(),
         summary.removed.len(),
         summary.denied.len(),
+        summary.duped.len(),
     );
 
     if !summary.promoted.is_empty() {
-        println!(
-            "\n{} {} rules",
-            "PROMOTE (local -> global):".cyan().bold(),
-            summary.promoted.len()
-        );
+        println!("\n{} {} rules", "PROMOTE (local -> global):".cyan().bold(), summary.promoted.len());
         print_rules(&summary.promoted, "+", 10);
     }
 
     if !summary.removed.is_empty() {
-        println!(
-            "\n{} {} rules",
-            "REMOVE (from local):".red().bold(),
-            summary.removed.len()
-        );
+        println!("\n{} {} rules", "REMOVE (from local):".red().bold(), summary.removed.len());
         print_rules(&summary.removed, "-", 10);
     }
 
     if !summary.denied.is_empty() {
-        println!(
-            "\n{} {} rules",
-            "DENY (remove from allow):".red().bold(),
-            summary.denied.len()
-        );
+        println!("\n{} {} rules", "DENY (remove from allow):".red().bold(), summary.denied.len());
         print_rules(&summary.denied, "x", 10);
+    }
+
+    if !summary.duped.is_empty() {
+        println!("\n{} {} rules", "DUPE (covered by broader rule):".yellow().bold(), summary.duped.len());
+        for (rule, source) in summary.duped.iter().take(10) {
+            println!("  - {rule}  [{source}]");
+        }
+        if summary.duped.len() > 10 {
+            println!("  ... ({} more)", summary.duped.len() - 10);
+        }
     }
 
     if summary.narrow_skipped > 0 {
@@ -265,33 +300,16 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)","Bash(tree:*)"]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: false,
-            deny: false,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
 
-        let global_allow: Vec<&str> = global["permissions"]["allow"]
-            .as_array()
-            .expect("array")
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
-        let local_allow: Vec<&str> = local["permissions"]["allow"]
-            .as_array()
-            .expect("array")
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
+        let global_allow: Vec<&str> = global["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
+        let local_allow: Vec<&str> = local["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
 
-        // ls and tree are safe -> should be promoted to global
         assert!(global_allow.contains(&"Bash(ls:*)"));
         assert!(global_allow.contains(&"Bash(tree:*)"));
-        // and removed from local
         assert!(!local_allow.contains(&"Bash(ls:*)"));
         assert!(!local_allow.contains(&"Bash(tree:*)"));
     }
@@ -305,24 +323,12 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","Bash(ls:*)"]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: false,
-            remove: true,
-            deny: false,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: true, deny: false, dupe: false }, true, false).expect("apply");
 
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
-        let local_allow: Vec<&str> = local["permissions"]["allow"]
-            .as_array()
-            .expect("array")
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
+        let local_allow: Vec<&str> = local["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
 
-        // sudo rm should be removed
         assert!(!local_allow.contains(&"Bash(sudo rm:*)"));
-        // ls should remain (it's safe, not dangerous)
         assert!(local_allow.contains(&"Bash(ls:*)"));
     }
 
@@ -335,24 +341,14 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: false,
-            deny: false,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
 
-        // Should not duplicate in global
-        let global_allow = global["permissions"]["allow"].as_array().expect("array");
-        let count = global_allow.iter().filter(|v| v.as_str() == Some("Bash(ls:*)")).count();
+        let count = global["permissions"]["allow"].as_array().expect("array").iter().filter(|v| v.as_str() == Some("Bash(ls:*)")).count();
         assert_eq!(count, 1);
-
-        // Should be removed from local
-        let local_allow = local["permissions"]["allow"].as_array().expect("array");
-        assert!(!local_allow.iter().any(|v| v.as_str() == Some("Bash(ls:*)")));
+        assert!(!local["permissions"]["allow"].as_array().expect("array").iter().any(|v| v.as_str() == Some("Bash(ls:*)")));
     }
 
     #[test]
@@ -362,15 +358,8 @@ mod tests {
         let local_json = r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#;
         let (gp, lp) = write_settings(dir.path(), global_json, local_json);
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: true,
-            deny: true,
-        };
-        // write=false means dry run
-        run_apply(&gp, &lp, &filter, false, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter::all(), false, false).expect("apply");
 
-        // Files should be unchanged
         assert_eq!(std::fs::read_to_string(&gp).expect("read"), global_json);
         assert_eq!(std::fs::read_to_string(&lp).expect("read"), local_json);
     }
@@ -384,13 +373,7 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)"]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: false,
-            remove: true,
-            deny: false,
-        };
-        // rkvr must be available in PATH; this is an integration smoke test
-        run_apply(&gp, &lp, &filter, true, true).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: true, deny: false, dupe: false }, true, true).expect("apply");
     }
 
     #[test]
@@ -402,12 +385,7 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)"]},"enableAllProjectMcpServers":true}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: false,
-            deny: false,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         assert_eq!(global["env"]["FOO"], "bar");
@@ -427,17 +405,10 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","Bash(ls:*)"]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: false,
-            remove: false,
-            deny: false,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: false, deny: false, dupe: false }, true, false).expect("apply");
 
-        // Nothing should change
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
-        let local_allow = local["permissions"]["allow"].as_array().expect("array");
-        assert_eq!(local_allow.len(), 2);
+        assert_eq!(local["permissions"]["allow"].as_array().expect("array").len(), 2);
     }
 
     #[test]
@@ -449,17 +420,10 @@ mod tests {
             r#"{"permissions":{"allow":[]}}"#,
         );
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: true,
-            deny: true,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter::all(), true, false).expect("apply");
 
-        // Deny-list rules should not be touched - they're already denied
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
-        let deny = global["permissions"]["deny"].as_array().expect("array");
-        assert_eq!(deny.len(), 2, "deny list should be unchanged");
+        assert_eq!(global["permissions"]["deny"].as_array().expect("array").len(), 2, "deny list should be unchanged");
     }
 
     #[test]
@@ -468,14 +432,46 @@ mod tests {
         let gp = dir.path().join("settings.json");
         let lp = dir.path().join("settings.local.json");
         std::fs::write(&gp, r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#).expect("write");
-        // local file does not exist
 
-        let filter = ApplyFilter {
-            promote: true,
-            remove: true,
-            deny: true,
-        };
-        run_apply(&gp, &lp, &filter, true, false).expect("apply");
-        // Should not panic
+        run_apply(&gp, &lp, &ApplyFilter::all(), true, false).expect("apply");
+    }
+
+    #[test]
+    fn dupe_removed_from_correct_file() {
+        let dir = TempDir::new().expect("temp");
+        // Edit(**) is broader - Edit(**/*.rs) is a dupe, lives in global
+        let (gp, lp) = write_settings(
+            dir.path(),
+            r#"{"permissions":{"allow":["Edit(**)", "Edit(**/*.rs)"]}}"#,
+            r#"{"permissions":{"allow":[]}}"#,
+        );
+
+        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: false, deny: false, dupe: true }, true, false).expect("apply");
+
+        let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
+        let global_allow: Vec<&str> = global["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
+
+        assert!(global_allow.contains(&"Edit(**)"));
+        assert!(!global_allow.contains(&"Edit(**/*.rs)"), "dupe should be removed");
+    }
+
+    #[test]
+    fn parse_apply_filter_empty_is_all() {
+        let f = parse_apply_filter(&[]).expect("parse");
+        assert!(f.promote && f.remove && f.deny && f.dupe);
+    }
+
+    #[test]
+    fn parse_apply_filter_specific() {
+        let f = parse_apply_filter(&["promote".to_string(), "dupe".to_string()]).expect("parse");
+        assert!(f.promote);
+        assert!(!f.remove);
+        assert!(!f.deny);
+        assert!(f.dupe);
+    }
+
+    #[test]
+    fn parse_apply_filter_unknown_errors() {
+        assert!(parse_apply_filter(&["foo".to_string()]).is_err());
     }
 }

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -18,7 +18,12 @@ pub struct ApplyFilter {
 impl ApplyFilter {
     /// All actionable recommendations.
     pub fn all() -> Self {
-        Self { promote: true, remove: true, deny: true, dupe: true }
+        Self {
+            promote: true,
+            remove: true,
+            deny: true,
+            dupe: true,
+        }
     }
 }
 
@@ -204,7 +209,13 @@ fn build_summary(entries: &[AuditEntry], filter: &ApplyFilter) -> ApplySummary {
         }
     }
 
-    ApplySummary { promoted, removed, denied, duped, narrow_skipped }
+    ApplySummary {
+        promoted,
+        removed,
+        denied,
+        duped,
+        narrow_skipped,
+    }
 }
 
 fn print_plan(summary: &ApplySummary, write: bool) {
@@ -219,22 +230,38 @@ fn print_plan(summary: &ApplySummary, write: bool) {
     );
 
     if !summary.promoted.is_empty() {
-        println!("\n{} {} rules", "PROMOTE (local -> global):".cyan().bold(), summary.promoted.len());
+        println!(
+            "\n{} {} rules",
+            "PROMOTE (local -> global):".cyan().bold(),
+            summary.promoted.len()
+        );
         print_rules(&summary.promoted, "+", 10);
     }
 
     if !summary.removed.is_empty() {
-        println!("\n{} {} rules", "REMOVE (from local):".red().bold(), summary.removed.len());
+        println!(
+            "\n{} {} rules",
+            "REMOVE (from local):".red().bold(),
+            summary.removed.len()
+        );
         print_rules(&summary.removed, "-", 10);
     }
 
     if !summary.denied.is_empty() {
-        println!("\n{} {} rules", "DENY (remove from allow):".red().bold(), summary.denied.len());
+        println!(
+            "\n{} {} rules",
+            "DENY (remove from allow):".red().bold(),
+            summary.denied.len()
+        );
         print_rules(&summary.denied, "x", 10);
     }
 
     if !summary.duped.is_empty() {
-        println!("\n{} {} rules", "DUPE (covered by broader rule):".yellow().bold(), summary.duped.len());
+        println!(
+            "\n{} {} rules",
+            "DUPE (covered by broader rule):".yellow().bold(),
+            summary.duped.len()
+        );
         for (rule, source) in summary.duped.iter().take(10) {
             println!("  - {rule}  [{source}]");
         }
@@ -300,13 +327,35 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)","Bash(tree:*)"]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: true,
+                remove: false,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
 
-        let global_allow: Vec<&str> = global["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
-        let local_allow: Vec<&str> = local["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
+        let global_allow: Vec<&str> = global["permissions"]["allow"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let local_allow: Vec<&str> = local["permissions"]["allow"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
 
         assert!(global_allow.contains(&"Bash(ls:*)"));
         assert!(global_allow.contains(&"Bash(tree:*)"));
@@ -323,10 +372,27 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","Bash(ls:*)"]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: true, deny: false, dupe: false }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: false,
+                remove: true,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
-        let local_allow: Vec<&str> = local["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
+        let local_allow: Vec<&str> = local["permissions"]["allow"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
 
         assert!(!local_allow.contains(&"Bash(sudo rm:*)"));
         assert!(local_allow.contains(&"Bash(ls:*)"));
@@ -341,14 +407,37 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: true,
+                remove: false,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
 
-        let count = global["permissions"]["allow"].as_array().expect("array").iter().filter(|v| v.as_str() == Some("Bash(ls:*)")).count();
+        let count = global["permissions"]["allow"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .filter(|v| v.as_str() == Some("Bash(ls:*)"))
+            .count();
         assert_eq!(count, 1);
-        assert!(!local["permissions"]["allow"].as_array().expect("array").iter().any(|v| v.as_str() == Some("Bash(ls:*)")));
+        assert!(
+            !local["permissions"]["allow"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .any(|v| v.as_str() == Some("Bash(ls:*)"))
+        );
     }
 
     #[test]
@@ -373,7 +462,19 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)"]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: true, deny: false, dupe: false }, true, true).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: false,
+                remove: true,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            true,
+        )
+        .expect("apply");
     }
 
     #[test]
@@ -385,7 +486,19 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(ls:*)"]},"enableAllProjectMcpServers":true}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: true, remove: false, deny: false, dupe: false }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: true,
+                remove: false,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         assert_eq!(global["env"]["FOO"], "bar");
@@ -405,7 +518,19 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","Bash(ls:*)"]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: false, deny: false, dupe: false }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: false,
+                remove: false,
+                deny: false,
+                dupe: false,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let local: Value = serde_json::from_str(&std::fs::read_to_string(&lp).expect("read")).expect("parse");
         assert_eq!(local["permissions"]["allow"].as_array().expect("array").len(), 2);
@@ -423,7 +548,11 @@ mod tests {
         run_apply(&gp, &lp, &ApplyFilter::all(), true, false).expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
-        assert_eq!(global["permissions"]["deny"].as_array().expect("array").len(), 2, "deny list should be unchanged");
+        assert_eq!(
+            global["permissions"]["deny"].as_array().expect("array").len(),
+            2,
+            "deny list should be unchanged"
+        );
     }
 
     #[test]
@@ -446,10 +575,27 @@ mod tests {
             r#"{"permissions":{"allow":[]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter { promote: false, remove: false, deny: false, dupe: true }, true, false).expect("apply");
+        run_apply(
+            &gp,
+            &lp,
+            &ApplyFilter {
+                promote: false,
+                remove: false,
+                deny: false,
+                dupe: true,
+            },
+            true,
+            false,
+        )
+        .expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
-        let global_allow: Vec<&str> = global["permissions"]["allow"].as_array().expect("array").iter().filter_map(|v| v.as_str()).collect();
+        let global_allow: Vec<&str> = global["permissions"]["allow"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
 
         assert!(global_allow.contains(&"Edit(**)"));
         assert!(!global_allow.contains(&"Edit(**/*.rs)"), "dupe should be removed");

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -453,29 +453,6 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&lp).expect("read"), local_json);
     }
 
-    #[test]
-    fn backup_runs_without_error() {
-        let dir = TempDir::new().expect("temp");
-        let (gp, lp) = write_settings(
-            dir.path(),
-            r#"{"permissions":{"allow":[]}}"#,
-            r#"{"permissions":{"allow":["Bash(sudo rm:*)"]}}"#,
-        );
-
-        run_apply(
-            &gp,
-            &lp,
-            &ApplyFilter {
-                promote: false,
-                remove: true,
-                deny: false,
-                dupe: false,
-            },
-            true,
-            true,
-        )
-        .expect("apply");
-    }
 
     #[test]
     fn preserves_non_permission_fields() {

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -93,15 +93,18 @@ pub fn apply_entries(
     let mut global: Value = serde_json::from_str(&global_content).context("Failed to parse settings.json")?;
     let mut local: Value = serde_json::from_str(&local_content).context("Failed to parse settings.local.json")?;
 
-    if backup {
+    if backup && which::which("rkvr").is_ok() {
         let mut args = vec![settings_path.to_str().expect("valid path")];
         if settings_local_path.exists() {
             args.push(settings_local_path.to_str().expect("valid path"));
         }
-        match std::process::Command::new("rkvr").arg("bkup").args(&args).status() {
-            Ok(status) if status.success() => {}
-            Ok(_) => eprintln!("warning: rkvr bkup failed; continuing without backup"),
-            Err(_) => eprintln!("warning: rkvr not found; continuing without backup"),
+        let status = std::process::Command::new("rkvr")
+            .arg("bkup")
+            .args(&args)
+            .status()
+            .context("Failed to run rkvr bkup")?;
+        if !status.success() {
+            bail!("rkvr bkup failed");
         }
     }
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -98,13 +98,10 @@ pub fn apply_entries(
         if settings_local_path.exists() {
             args.push(settings_local_path.to_str().expect("valid path"));
         }
-        let status = std::process::Command::new("rkvr")
-            .arg("bkup")
-            .args(&args)
-            .status()
-            .context("Failed to run rkvr bkup")?;
-        if !status.success() {
-            bail!("rkvr bkup failed");
+        match std::process::Command::new("rkvr").arg("bkup").args(&args).status() {
+            Ok(status) if status.success() => {}
+            Ok(_) => eprintln!("warning: rkvr bkup failed; continuing without backup"),
+            Err(_) => eprintln!("warning: rkvr not found; continuing without backup"),
         }
     }
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -31,7 +31,7 @@ pub fn run_apply(
     backup: bool,
 ) -> Result<()> {
     // Run audit to get recommendations
-    let entries = audit(settings_path, settings_local_path, None)?;
+    let entries = audit(settings_path, settings_local_path, &[], None)?;
 
     // Partition entries by recommendation
     let summary = build_summary(&entries, filter);

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -453,7 +453,6 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&lp).expect("read"), local_json);
     }
 
-
     #[test]
     fn preserves_non_permission_fields() {
         let dir = TempDir::new().expect("temp");

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -2,6 +2,7 @@ use eyre::Result;
 use serde::Serialize;
 use std::path::Path;
 
+use crate::cmd::apply::{apply_entries, parse_apply_filter};
 use crate::filter::filter_by_patterns;
 use crate::pager::page_output;
 use crate::risk::{Recommendation, RiskTier, classify_rule, recommend, subsumes};
@@ -119,6 +120,7 @@ pub fn run_audit(
     patterns: &[String],
     format: &str,
     risk_filter: Option<RiskTier>,
+    apply: Option<&[String]>,
     pager: Option<&str>,
 ) -> Result<()> {
     let entries = audit(settings_path, settings_local_path, patterns, risk_filter)?;
@@ -138,32 +140,21 @@ pub fn run_audit(
         _ => page_output(&format_table(&entries), pager),
     }
 
-    // Summary
     let total = entries.len();
-    let deny_count = entries
-        .iter()
-        .filter(|e| e.recommendation == Recommendation::Deny)
-        .count();
-    let narrow_count = entries
-        .iter()
-        .filter(|e| e.recommendation == Recommendation::Narrow)
-        .count();
-    let promote_count = entries
-        .iter()
-        .filter(|e| e.recommendation == Recommendation::Promote)
-        .count();
-    let remove_count = entries
-        .iter()
-        .filter(|e| e.recommendation == Recommendation::Remove)
-        .count();
-    let dupe_count = entries
-        .iter()
-        .filter(|e| e.recommendation == Recommendation::Dupe)
-        .count();
+    let deny_count = entries.iter().filter(|e| e.recommendation == Recommendation::Deny).count();
+    let narrow_count = entries.iter().filter(|e| e.recommendation == Recommendation::Narrow).count();
+    let promote_count = entries.iter().filter(|e| e.recommendation == Recommendation::Promote).count();
+    let remove_count = entries.iter().filter(|e| e.recommendation == Recommendation::Remove).count();
+    let dupe_count = entries.iter().filter(|e| e.recommendation == Recommendation::Dupe).count();
 
     eprintln!(
         "\n{total} rules audited: {promote_count} promote, {narrow_count} narrow, {remove_count} remove, {deny_count} deny, {dupe_count} dupe"
     );
+
+    if let Some(actions) = apply {
+        let filter = parse_apply_filter(actions)?;
+        apply_entries(&entries, &filter, settings_path, settings_local_path, true, true)?;
+    }
 
     Ok(())
 }

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -45,19 +45,17 @@ pub fn audit(
     // Mark rules made redundant by a broader rule in the same list (allow or deny).
     // Cross-list matches are intentional: deny rules carve out from a broad allow.
     // Permanent-deny rules (Recommendation::Deny) are never overridden.
-    let snapshots: Vec<(String, String)> = entries
-        .iter()
-        .map(|e| (e.list.clone(), e.rule.clone()))
-        .collect();
-    for i in 0..entries.len() {
-        if entries[i].recommendation == Recommendation::Deny {
+    let snapshots: Vec<(String, String)> = entries.iter().map(|e| (e.list.clone(), e.rule.clone())).collect();
+    for (i, entry) in entries.iter_mut().enumerate() {
+        if entry.recommendation == Recommendation::Deny {
             continue;
         }
-        let covered = snapshots.iter().enumerate().any(|(j, (list, rule))| {
-            j != i && *list == entries[i].list && subsumes(rule, &entries[i].rule)
-        });
+        let covered = snapshots
+            .iter()
+            .enumerate()
+            .any(|(j, (list, rule))| j != i && *list == entry.list && subsumes(rule, &entry.rule));
         if covered {
-            entries[i].recommendation = Recommendation::Dupe;
+            entry.recommendation = Recommendation::Dupe;
         }
     }
 
@@ -141,11 +139,26 @@ pub fn run_audit(
     }
 
     let total = entries.len();
-    let deny_count = entries.iter().filter(|e| e.recommendation == Recommendation::Deny).count();
-    let narrow_count = entries.iter().filter(|e| e.recommendation == Recommendation::Narrow).count();
-    let promote_count = entries.iter().filter(|e| e.recommendation == Recommendation::Promote).count();
-    let remove_count = entries.iter().filter(|e| e.recommendation == Recommendation::Remove).count();
-    let dupe_count = entries.iter().filter(|e| e.recommendation == Recommendation::Dupe).count();
+    let deny_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Deny)
+        .count();
+    let narrow_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Narrow)
+        .count();
+    let promote_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Promote)
+        .count();
+    let remove_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Remove)
+        .count();
+    let dupe_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Dupe)
+        .count();
 
     eprintln!(
         "\n{total} rules audited: {promote_count} promote, {narrow_count} narrow, {remove_count} remove, {deny_count} deny, {dupe_count} dupe"
@@ -273,10 +286,16 @@ mod tests {
 
         let entries = audit(&gp, &lp, &[], None).expect("audit");
 
-        let edit_specific = entries.iter().find(|e| e.rule == "Edit(**/*.rs)").expect("edit specific");
+        let edit_specific = entries
+            .iter()
+            .find(|e| e.rule == "Edit(**/*.rs)")
+            .expect("edit specific");
         assert_eq!(edit_specific.recommendation, Recommendation::Dupe);
 
-        let git_specific = entries.iter().find(|e| e.rule == "Bash(git status:*)").expect("git status");
+        let git_specific = entries
+            .iter()
+            .find(|e| e.rule == "Bash(git status:*)")
+            .expect("git status");
         assert_eq!(git_specific.recommendation, Recommendation::Dupe);
 
         // The broader rules keep their own recommendations

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -2,8 +2,9 @@ use eyre::Result;
 use serde::Serialize;
 use std::path::Path;
 
+use crate::filter::filter_by_patterns;
 use crate::pager::page_output;
-use crate::risk::{Recommendation, RiskTier, classify_rule, recommend};
+use crate::risk::{Recommendation, RiskTier, classify_rule, recommend, subsumes};
 use crate::settings::load_settings;
 
 /// A single row in the audit output.
@@ -20,6 +21,7 @@ pub struct AuditEntry {
 pub fn audit(
     settings_path: &Path,
     settings_local_path: &Path,
+    patterns: &[String],
     risk_filter: Option<RiskTier>,
 ) -> Result<Vec<AuditEntry>> {
     let rules = load_settings(settings_path, settings_local_path)?;
@@ -39,10 +41,34 @@ pub fn audit(
         })
         .collect();
 
-    // Apply risk filter if specified
-    if let Some(filter) = risk_filter {
-        entries.retain(|e| e.risk == filter);
+    // Mark rules made redundant by a broader rule in the same list (allow or deny).
+    // Cross-list matches are intentional: deny rules carve out from a broad allow.
+    // Permanent-deny rules (Recommendation::Deny) are never overridden.
+    let snapshots: Vec<(String, String)> = entries
+        .iter()
+        .map(|e| (e.list.clone(), e.rule.clone()))
+        .collect();
+    for i in 0..entries.len() {
+        if entries[i].recommendation == Recommendation::Deny {
+            continue;
+        }
+        let covered = snapshots.iter().enumerate().any(|(j, (list, rule))| {
+            j != i && *list == entries[i].list && subsumes(rule, &entries[i].rule)
+        });
+        if covered {
+            entries[i].recommendation = Recommendation::Dupe;
+        }
     }
+
+    // Apply pattern filter (exact -> prefix -> substring cascade)
+    let entries = filter_by_patterns(entries, patterns, |e| e.rule.as_str());
+
+    // Apply risk filter on the already-narrowed set
+    let entries = if let Some(filter) = risk_filter {
+        entries.into_iter().filter(|e| e.risk == filter).collect()
+    } else {
+        entries
+    };
 
     Ok(entries)
 }
@@ -90,11 +116,12 @@ pub fn format_json(entries: &[AuditEntry]) -> Result<String> {
 pub fn run_audit(
     settings_path: &Path,
     settings_local_path: &Path,
+    patterns: &[String],
     format: &str,
     risk_filter: Option<RiskTier>,
     pager: Option<&str>,
 ) -> Result<()> {
-    let entries = audit(settings_path, settings_local_path, risk_filter)?;
+    let entries = audit(settings_path, settings_local_path, patterns, risk_filter)?;
 
     match format {
         "json" => println!("{}", format_json(&entries)?),
@@ -129,9 +156,13 @@ pub fn run_audit(
         .iter()
         .filter(|e| e.recommendation == Recommendation::Remove)
         .count();
+    let dupe_count = entries
+        .iter()
+        .filter(|e| e.recommendation == Recommendation::Dupe)
+        .count();
 
     eprintln!(
-        "\n{total} rules audited: {promote_count} promote, {narrow_count} narrow, {remove_count} remove, {deny_count} deny"
+        "\n{total} rules audited: {promote_count} promote, {narrow_count} narrow, {remove_count} remove, {deny_count} deny, {dupe_count} dupe"
     );
 
     Ok(())
@@ -159,7 +190,7 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","WebSearch"]}}"#,
         );
 
-        let entries = audit(&gp, &lp, None).expect("audit");
+        let entries = audit(&gp, &lp, &[], None).expect("audit");
         assert_eq!(entries.len(), 5);
 
         // ls is safe
@@ -186,7 +217,7 @@ mod tests {
             r#"{"permissions":{}}"#,
         );
 
-        let entries = audit(&gp, &lp, Some(RiskTier::Dangerous)).expect("audit");
+        let entries = audit(&gp, &lp, &[], Some(RiskTier::Dangerous)).expect("audit");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].rule, "Bash(sudo rm:*)");
     }
@@ -235,7 +266,30 @@ mod tests {
             r#"{"permissions":{}}"#,
         );
 
-        let entries = audit(&gp, &lp, None).expect("audit");
+        let entries = audit(&gp, &lp, &[], None).expect("audit");
         assert_eq!(entries[0].recommendation, Recommendation::Narrow);
+    }
+
+    #[test]
+    fn redundant_when_broader_rule_exists() {
+        let dir = TempDir::new().expect("temp");
+        // Edit(**) is broader than Edit(**/*.rs) — the specific one should be redundant
+        let (gp, lp) = write_settings(
+            dir.path(),
+            r#"{"permissions":{"allow":["Edit(**)", "Edit(**/*.rs)", "Bash(git:*)", "Bash(git status:*)"]}}"#,
+            r#"{"permissions":{}}"#,
+        );
+
+        let entries = audit(&gp, &lp, &[], None).expect("audit");
+
+        let edit_specific = entries.iter().find(|e| e.rule == "Edit(**/*.rs)").expect("edit specific");
+        assert_eq!(edit_specific.recommendation, Recommendation::Dupe);
+
+        let git_specific = entries.iter().find(|e| e.rule == "Bash(git status:*)").expect("git status");
+        assert_eq!(git_specific.recommendation, Recommendation::Dupe);
+
+        // The broader rules keep their own recommendations
+        let edit_broad = entries.iter().find(|e| e.rule == "Edit(**)").expect("edit broad");
+        assert_ne!(edit_broad.recommendation, Recommendation::Dupe);
     }
 }

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -2,6 +2,7 @@ use eyre::Result;
 use serde::Serialize;
 use std::path::Path;
 
+use crate::pager::page_output;
 use crate::risk::{Recommendation, RiskTier, classify_rule, recommend};
 use crate::settings::load_settings;
 
@@ -52,36 +53,28 @@ pub fn format_table(entries: &[AuditEntry]) -> String {
         return "No rules found.".to_string();
     }
 
-    // Column widths
-    let rule_width = entries.iter().map(|e| e.rule.len()).max().unwrap_or(4).clamp(4, 60);
-    let list_width = 5;
     let source_width = 6;
     let risk_width = 9;
-    let rec_width = 14;
+    let action_width = 7; // "promote" is the longest value
+    let list_width = 5;
 
     let mut out = String::new();
 
-    // Header
+    // Header — Rule is last so it needs no padding
     out.push_str(&format!(
-        "{:<rule_width$}  {:<list_width$}  {:<source_width$}  {:<risk_width$}  {:<rec_width$}\n",
-        "Rule", "List", "Source", "Risk", "Recommendation"
+        "{:<source_width$}  {:<risk_width$}  {:<action_width$}  {:<list_width$}  {}\n",
+        "Source", "Risk", "Action", "List", "Rule"
     ));
     out.push_str(&format!(
-        "{:-<rule_width$}  {:-<list_width$}  {:-<source_width$}  {:-<risk_width$}  {:-<rec_width$}\n",
+        "{:-<source_width$}  {:-<risk_width$}  {:-<action_width$}  {:-<list_width$}  {:-<4}\n",
         "", "", "", "", ""
     ));
 
     // Rows
     for entry in entries {
-        let rule_display = if entry.rule.chars().count() > rule_width {
-            let truncated: String = entry.rule.chars().take(rule_width - 3).collect();
-            format!("{truncated}...")
-        } else {
-            entry.rule.clone()
-        };
         out.push_str(&format!(
-            "{:<rule_width$}  {:<list_width$}  {:<source_width$}  {:<risk_width$}  {:<rec_width$}\n",
-            rule_display, entry.list, entry.source, entry.risk, entry.recommendation
+            "{:<source_width$}  {:<risk_width$}  {:<action_width$}  {:<list_width$}  {}\n",
+            entry.source, entry.risk, entry.recommendation, entry.list, entry.rule
         ));
     }
 
@@ -99,21 +92,23 @@ pub fn run_audit(
     settings_local_path: &Path,
     format: &str,
     risk_filter: Option<RiskTier>,
+    pager: Option<&str>,
 ) -> Result<()> {
     let entries = audit(settings_path, settings_local_path, risk_filter)?;
 
     match format {
         "json" => println!("{}", format_json(&entries)?),
         "markdown" => {
-            // Markdown uses same table format with pipes
+            let mut out = String::new();
             for entry in &entries {
-                println!(
-                    "| {} | {} | {} | {} | {} |",
-                    entry.rule, entry.list, entry.source, entry.risk, entry.recommendation
-                );
+                out.push_str(&format!(
+                    "| {} | {} | {} | {} | {} |\n",
+                    entry.source, entry.risk, entry.recommendation, entry.list, entry.rule
+                ));
             }
+            page_output(&out, pager);
         }
-        _ => print!("{}", format_table(&entries)),
+        _ => page_output(&format_table(&entries), pager),
     }
 
     // Summary

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -9,8 +9,7 @@ use std::path::Path;
 pub fn run_install(settings_path: &Path, yes: bool) -> Result<bool> {
     // Read or create settings
     let mut root: Map<String, Value> = if settings_path.exists() {
-        let content =
-            std::fs::read_to_string(settings_path).context("Failed to read settings file")?;
+        let content = std::fs::read_to_string(settings_path).context("Failed to read settings file")?;
         serde_json::from_str(&content).context("Failed to parse settings JSON")?
     } else {
         if !yes {
@@ -38,10 +37,7 @@ pub fn run_install(settings_path: &Path, yes: bool) -> Result<bool> {
     }
 
     if !yes {
-        println!(
-            "Would add claude-permit PreToolUse hook to {}",
-            settings_path.display()
-        );
+        println!("Would add claude-permit PreToolUse hook to {}", settings_path.display());
         println!("Pass --yes to apply.");
         return Ok(false);
     }
@@ -51,8 +47,7 @@ pub fn run_install(settings_path: &Path, yes: bool) -> Result<bool> {
 
     // Write back
     let output = serde_json::to_string_pretty(&root).context("Failed to serialize settings")?;
-    std::fs::write(settings_path, format!("{output}\n"))
-        .context("Failed to write settings file")?;
+    std::fs::write(settings_path, format!("{output}\n")).context("Failed to write settings file")?;
 
     println!(
         "{} Installed claude-permit hook in {}",
@@ -183,16 +178,11 @@ mod tests {
     fn install_preserves_other_fields() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("settings.json");
-        std::fs::write(
-            &path,
-            r#"{"model": "opus", "permissions": {"allow": ["Bash(ls:*)"]}}"#,
-        )
-        .unwrap();
+        std::fs::write(&path, r#"{"model": "opus", "permissions": {"allow": ["Bash(ls:*)"]}}"#).unwrap();
 
         run_install(&path, true).unwrap();
 
-        let root: Map<String, Value> =
-            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let root: Map<String, Value> = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(root.get("model").and_then(|v| v.as_str()), Some("opus"));
         assert!(root.get("permissions").is_some());
         assert!(root.get("hooks").is_some());

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -7,7 +7,6 @@ mod log;
 mod report;
 mod suggest;
 
-pub use apply::run_apply;
 pub use audit::run_audit;
 pub use check::run_check;
 pub use clean::run_clean;

--- a/src/cmd/report.rs
+++ b/src/cmd/report.rs
@@ -2,6 +2,7 @@ use eyre::Result;
 use serde::Serialize;
 
 use crate::db::EventStore;
+use crate::pager::page_output;
 use crate::risk::{RiskTier, classify_tool_input};
 
 /// Summary of a session's permission activity.
@@ -87,7 +88,7 @@ pub fn report(store: &EventStore, session_id: Option<&str>) -> Result<SessionRep
 }
 
 /// Run the report command with output formatting.
-pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str) -> Result<()> {
+pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str, pager: Option<&str>) -> Result<()> {
     let rep = report(store, session_id)?;
 
     if rep.total_events == 0 {
@@ -98,27 +99,30 @@ pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str) ->
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(&rep)?),
         _ => {
-            println!("Session: {}", rep.session_id);
-            println!(
-                "Events: {} total ({} safe, {} moderate, {} dangerous)",
+            let mut out = String::new();
+            out.push_str(&format!("Session: {}\n", rep.session_id));
+            out.push_str(&format!(
+                "Events: {} total ({} safe, {} moderate, {} dangerous)\n",
                 rep.total_events, rep.safe_count, rep.moderate_count, rep.dangerous_count
-            );
-            println!();
+            ));
+            out.push('\n');
 
             if !rep.tool_counts.is_empty() {
-                println!("Tool usage:");
+                out.push_str("Tool usage:\n");
                 for tc in &rep.tool_counts {
-                    println!("  {:<20} {}", tc.tool_name, tc.count);
+                    out.push_str(&format!("  {:<20} {}\n", tc.tool_name, tc.count));
                 }
-                println!();
+                out.push('\n');
             }
 
             if !rep.dangerous_events.is_empty() {
-                println!("Dangerous activity:");
+                out.push_str("Dangerous activity:\n");
                 for de in &rep.dangerous_events {
-                    println!("  {} {} ({})", de.tool_name, de.tool_input, de.timestamp);
+                    out.push_str(&format!("  {} {} ({})\n", de.tool_name, de.tool_input, de.timestamp));
                 }
             }
+
+            page_output(&out, pager);
         }
     }
 

--- a/src/cmd/suggest.rs
+++ b/src/cmd/suggest.rs
@@ -1,8 +1,26 @@
+use std::collections::HashMap;
+
 use eyre::Result;
 use serde::Serialize;
 
 use crate::db::EventStore;
 use crate::risk::{RiskTier, classify_tool_input};
+
+/// Internal Claude mechanics tools - not relevant for permission rules.
+const SKIP_TOOLS: &[&str] = &[
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskGet",
+    "TaskList",
+    "TaskStop",
+    "TaskOutput",
+    "ExitPlanMode",
+    "EnterPlanMode",
+    "SendMessage",
+    "ToolSearch",
+    "Skill",
+    "Agent",
+];
 
 /// A suggestion row for output.
 #[derive(Debug, Serialize)]
@@ -18,21 +36,45 @@ pub struct SuggestEntry {
 pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32) -> Result<Vec<SuggestEntry>> {
     let patterns = store.suggest_patterns(threshold, min_sessions)?;
 
-    let entries: Vec<SuggestEntry> = patterns
+    // Compute suggested rules, filtering noise tools.
+    // DB returns rows ordered by count DESC, so first hit per rule is highest-frequency.
+    let raw: Vec<(String, String, i64, i64, RiskTier)> = patterns
         .into_iter()
+        .filter(|p| !SKIP_TOOLS.contains(&p.tool_name.as_str()))
         .map(|p| {
             let risk = classify_tool_input(&p.tool_name, &p.tool_input);
             let suggested_rule = make_rule(&p.tool_name, &p.tool_input);
             let pattern = format_pattern(&p.tool_name, &p.tool_input);
-            SuggestEntry {
-                pattern,
-                count: p.count,
-                sessions: p.sessions,
-                suggested_rule,
-                risk,
-            }
+            (pattern, suggested_rule, p.count, p.sessions, risk)
         })
         .collect();
+
+    // Deduplicate by suggested_rule: sum counts, take max sessions.
+    // Multiple raw inputs can normalize to the same rule (e.g. "otto ci --flag1"
+    // and "otto ci --flag2" both become Bash(otto ci:*)).
+    let mut deduped: HashMap<String, (String, i64, i64, RiskTier)> = HashMap::new();
+    for (pattern, rule, count, sessions, risk) in raw {
+        let entry = deduped
+            .entry(rule.clone())
+            .or_insert_with(|| (pattern, 0, 0, risk));
+        entry.1 += count;
+        if sessions > entry.2 {
+            entry.2 = sessions;
+        }
+    }
+
+    let mut entries: Vec<SuggestEntry> = deduped
+        .into_iter()
+        .map(|(rule, (pattern, count, sessions, risk))| SuggestEntry {
+            pattern,
+            count,
+            sessions,
+            suggested_rule: rule,
+            risk,
+        })
+        .collect();
+
+    entries.sort_by(|a, b| b.count.cmp(&a.count));
 
     Ok(entries)
 }
@@ -44,12 +86,10 @@ fn make_rule(tool_name: &str, tool_input: &str) -> String {
             let prefix = command_prefix(tool_input);
             format!("Bash({prefix}:*)")
         }
-        "Edit" | "Write" | "Read" => {
-            // Derive a glob from the file path
-            format!("{tool_name}({tool_input})")
+        "Edit" | "Write" | "Read" | "Glob" | "Grep" => {
+            tool_name.to_string()
         }
         "WebFetch" => {
-            // Extract domain from URL
             if let Some(domain) = extract_domain(tool_input) {
                 format!("WebFetch(domain:{domain})")
             } else {
@@ -68,7 +108,6 @@ fn command_prefix(cmd: &str) -> String {
         [] => String::new(),
         [single] => (*single).to_string(),
         [first, second, ..] => {
-            // Two-word prefixes for common compound commands
             let compound = ["git", "docker", "cargo", "gh", "otto", "sudo", "systemctl", "apt"];
             if compound.contains(first) {
                 format!("{first} {second}")
@@ -79,11 +118,38 @@ fn command_prefix(cmd: &str) -> String {
     }
 }
 
-/// Format a human-readable pattern description.
+/// Format a short human-readable pattern label.
 fn format_pattern(tool_name: &str, tool_input: &str) -> String {
     match tool_name {
         "Bash" => command_prefix(tool_input),
-        _ => format!("{tool_name}:{tool_input}"),
+        "Read" | "Edit" | "Write" | "Glob" | "Grep" => {
+            tool_name.to_string()
+        }
+        _ => {
+            let input = collapse_home(tool_input);
+            format!("{tool_name} {input}")
+        }
+    }
+}
+
+/// Replace $HOME prefix with `~`.
+fn collapse_home(path: &str) -> String {
+    if let Some(home) = dirs::home_dir() {
+        let home_str = home.to_string_lossy();
+        if let Some(rest) = path.strip_prefix(home_str.as_ref()) {
+            return format!("~{rest}");
+        }
+    }
+    path.to_string()
+}
+
+/// Truncate a string to `max` chars, appending `...` if cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let cut = s.char_indices().nth(max - 3).map(|(i, _)| i).unwrap_or(s.len());
+        format!("{}...", &s[..cut])
     }
 }
 
@@ -107,27 +173,26 @@ pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, format
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(&entries)?),
         _ => {
-            let pattern_width = entries.iter().map(|e| e.pattern.len()).max().unwrap_or(7).clamp(7, 30);
-            let rule_width = entries
-                .iter()
-                .map(|e| e.suggested_rule.len())
-                .max()
-                .unwrap_or(14)
-                .clamp(14, 40);
+            const PAT_MAX: usize = 36;
+            const RULE_MAX: usize = 48;
 
             println!(
-                "{:<pattern_width$}  {:>5}  {:>8}  {:<rule_width$}  Risk",
-                "Pattern", "Count", "Sessions", "Suggested Rule"
+                "{:<PAT_MAX$}  {:>5}  {:>8}  {:<RULE_MAX$}  {}",
+                "Pattern", "Count", "Sessions", "Suggested Rule", "Risk"
             );
             println!(
-                "{:-<pattern_width$}  {:->5}  {:->8}  {:-<rule_width$}  {:-<9}",
+                "{:-<PAT_MAX$}  {:->5}  {:->8}  {:-<RULE_MAX$}  {:-<8}",
                 "", "", "", "", ""
             );
 
             for entry in &entries {
                 println!(
-                    "{:<pattern_width$}  {:>5}  {:>8}  {:<rule_width$}  {}",
-                    entry.pattern, entry.count, entry.sessions, entry.suggested_rule, entry.risk
+                    "{:<PAT_MAX$}  {:>5}  {:>8}  {:<RULE_MAX$}  {}",
+                    truncate(&entry.pattern, PAT_MAX),
+                    entry.count,
+                    entry.sessions,
+                    truncate(&entry.suggested_rule, RULE_MAX),
+                    entry.risk
                 );
             }
         }
@@ -181,17 +246,86 @@ mod tests {
     }
 
     #[test]
-    fn extract_domain_basic() {
-        assert_eq!(extract_domain("https://docs.rs/clap"), Some("docs.rs".into()));
-        assert_eq!(extract_domain("http://example.com/path"), Some("example.com".into()));
+    fn truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long() {
+        let s = "abcdefghijklmnop";
+        let result = truncate(s, 10);
+        assert_eq!(result, "abcdefg...");
+        assert_eq!(result.chars().count(), 10);
+    }
+
+    #[test]
+    fn suggest_deduplicates_bash_variants() {
+        let dir = tempfile::TempDir::new().expect("temp");
+        let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
+
+        // Two variants of "otto ci" with different flags, across enough sessions
+        for i in 0..5 {
+            let session = format!("s{i}");
+            store
+                .insert_event(
+                    "2026-03-24T12:00:00Z",
+                    &session,
+                    "Bash",
+                    "otto ci --fast",
+                    None,
+                    None,
+                    None,
+                )
+                .expect("insert");
+            store
+                .insert_event(
+                    "2026-03-24T12:01:00Z",
+                    &session,
+                    "Bash",
+                    "otto ci",
+                    None,
+                    None,
+                    None,
+                )
+                .expect("insert");
+        }
+
+        let entries = suggest(&store, 3, 2).expect("suggest");
+        // Both variants normalize to Bash(otto ci:*) - should be one entry
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].suggested_rule, "Bash(otto ci:*)");
+        assert_eq!(entries[0].count, 10); // summed
+    }
+
+    #[test]
+    fn suggest_filters_task_tools() {
+        let dir = tempfile::TempDir::new().expect("temp");
+        let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
+
+        for i in 0..5 {
+            let session = format!("s{i}");
+            store
+                .insert_event(
+                    "2026-03-24T12:00:00Z",
+                    &session,
+                    "TaskUpdate",
+                    r#"{"status":"completed","taskId":"1"}"#,
+                    None,
+                    None,
+                    None,
+                )
+                .expect("insert");
+        }
+
+        let entries = suggest(&store, 3, 2).expect("suggest");
+        assert!(entries.is_empty(), "TaskUpdate should be filtered out");
     }
 
     #[test]
     fn suggest_with_db() {
         let dir = tempfile::TempDir::new().expect("temp");
-        let store = EventStore::open(&dir.path().join("test.db")).expect("open");
+        let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
 
-        // Insert events across multiple sessions
         for i in 0..5 {
             let session = format!("s{}", i % 3);
             store

--- a/src/cmd/suggest.rs
+++ b/src/cmd/suggest.rs
@@ -56,9 +56,7 @@ pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32) -> Result<
     // and "otto ci --flag2" both become Bash(otto ci:*)).
     let mut deduped: HashMap<String, (String, i64, i64, RiskTier)> = HashMap::new();
     for (pattern, rule, count, sessions, risk) in raw {
-        let entry = deduped
-            .entry(rule.clone())
-            .or_insert_with(|| (pattern, 0, 0, risk));
+        let entry = deduped.entry(rule.clone()).or_insert_with(|| (pattern, 0, 0, risk));
         entry.1 += count;
         if sessions > entry.2 {
             entry.2 = sessions;
@@ -124,9 +122,7 @@ fn command_prefix(cmd: &str) -> String {
 fn format_pattern(tool_name: &str, tool_input: &str) -> String {
     match tool_name {
         "Bash" => command_prefix(tool_input),
-        "Read" | "Edit" | "Write" | "Glob" | "Grep" => {
-            tool_name.to_string()
-        }
+        "Read" | "Edit" | "Write" | "Glob" | "Grep" => tool_name.to_string(),
         _ => {
             let input = collapse_home(tool_input);
             format!("{tool_name} {input}")
@@ -154,7 +150,14 @@ fn extract_domain(url: &str) -> Option<String> {
 }
 
 /// Run the suggest command with output formatting.
-pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, patterns: &[String], format: &str, pager: Option<&str>) -> Result<()> {
+pub fn run_suggest(
+    store: &EventStore,
+    threshold: u32,
+    min_sessions: u32,
+    patterns: &[String],
+    format: &str,
+    pager: Option<&str>,
+) -> Result<()> {
     let entries = suggest(store, threshold, min_sessions)?;
     let entries = filter_by_patterns(entries, patterns, |e| e.suggested_rule.as_str());
 
@@ -181,11 +184,16 @@ pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, patter
             let mut out = String::new();
             let sep = format!("{:-<9}  {:->5}  {:->8}  {:-<rw$}", "", "", "", "");
 
-            writeln!(out, "{:<9}  {:>5}  {:>8}  {}", "Risk", "Count", "Sessions", "Rule").unwrap();
+            writeln!(out, "{:<9}  {:>5}  {:>8}  Rule", "Risk", "Count", "Sessions").unwrap();
             writeln!(out, "{sep}").unwrap();
 
             for e in &claude_entries {
-                writeln!(out, "{:<9}  {:>5}  {:>8}  {}", e.risk, e.count, e.sessions, e.suggested_rule).unwrap();
+                writeln!(
+                    out,
+                    "{:<9}  {:>5}  {:>8}  {}",
+                    e.risk, e.count, e.sessions, e.suggested_rule
+                )
+                .unwrap();
             }
 
             if !claude_entries.is_empty() && !system_entries.is_empty() {
@@ -193,7 +201,12 @@ pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, patter
             }
 
             for e in &system_entries {
-                writeln!(out, "{:<9}  {:>5}  {:>8}  {}", e.risk, e.count, e.sessions, e.suggested_rule).unwrap();
+                writeln!(
+                    out,
+                    "{:<9}  {:>5}  {:>8}  {}",
+                    e.risk, e.count, e.sessions, e.suggested_rule
+                )
+                .unwrap();
             }
 
             page_output(&out, pager);
@@ -267,15 +280,7 @@ mod tests {
                 )
                 .expect("insert");
             store
-                .insert_event(
-                    "2026-03-24T12:01:00Z",
-                    &session,
-                    "Bash",
-                    "otto ci",
-                    None,
-                    None,
-                    None,
-                )
+                .insert_event("2026-03-24T12:01:00Z", &session, "Bash", "otto ci", None, None, None)
                 .expect("insert");
         }
 

--- a/src/cmd/suggest.rs
+++ b/src/cmd/suggest.rs
@@ -4,7 +4,8 @@ use eyre::Result;
 use serde::Serialize;
 
 use crate::db::EventStore;
-use crate::risk::{RiskTier, classify_tool_input};
+use crate::pager::page_output;
+use crate::risk::{RiskTier, classify_rule};
 
 /// Internal Claude mechanics tools - not relevant for permission rules.
 const SKIP_TOOLS: &[&str] = &[
@@ -42,8 +43,8 @@ pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32) -> Result<
         .into_iter()
         .filter(|p| !SKIP_TOOLS.contains(&p.tool_name.as_str()))
         .map(|p| {
-            let risk = classify_tool_input(&p.tool_name, &p.tool_input);
             let suggested_rule = make_rule(&p.tool_name, &p.tool_input);
+            let risk = classify_rule(&suggested_rule);
             let pattern = format_pattern(&p.tool_name, &p.tool_input);
             (pattern, suggested_rule, p.count, p.sessions, risk)
         })
@@ -87,7 +88,7 @@ fn make_rule(tool_name: &str, tool_input: &str) -> String {
             format!("Bash({prefix}:*)")
         }
         "Edit" | "Write" | "Read" | "Glob" | "Grep" => {
-            tool_name.to_string()
+            format!("{tool_name}(**)")
         }
         "WebFetch" => {
             if let Some(domain) = extract_domain(tool_input) {
@@ -143,16 +144,6 @@ fn collapse_home(path: &str) -> String {
     path.to_string()
 }
 
-/// Truncate a string to `max` chars, appending `...` if cut.
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let cut = s.char_indices().nth(max - 3).map(|(i, _)| i).unwrap_or(s.len());
-        format!("{}...", &s[..cut])
-    }
-}
-
 /// Extract domain from a URL.
 fn extract_domain(url: &str) -> Option<String> {
     url.split("//")
@@ -162,7 +153,7 @@ fn extract_domain(url: &str) -> Option<String> {
 }
 
 /// Run the suggest command with output formatting.
-pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, format: &str) -> Result<()> {
+pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, format: &str, pager: Option<&str>) -> Result<()> {
     let entries = suggest(store, threshold, min_sessions)?;
 
     if entries.is_empty() {
@@ -173,28 +164,37 @@ pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, format
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(&entries)?),
         _ => {
-            const PAT_MAX: usize = 36;
-            const RULE_MAX: usize = 48;
+            use std::fmt::Write as FmtWrite;
 
-            println!(
-                "{:<PAT_MAX$}  {:>5}  {:>8}  {:<RULE_MAX$}  {}",
-                "Pattern", "Count", "Sessions", "Suggested Rule", "Risk"
-            );
-            println!(
-                "{:-<PAT_MAX$}  {:->5}  {:->8}  {:-<RULE_MAX$}  {:-<8}",
-                "", "", "", "", ""
-            );
+            let (claude_entries, system_entries): (Vec<_>, Vec<_>) =
+                entries.iter().partition(|e| !e.suggested_rule.starts_with("Bash("));
 
-            for entry in &entries {
-                println!(
-                    "{:<PAT_MAX$}  {:>5}  {:>8}  {:<RULE_MAX$}  {}",
-                    truncate(&entry.pattern, PAT_MAX),
-                    entry.count,
-                    entry.sessions,
-                    truncate(&entry.suggested_rule, RULE_MAX),
-                    entry.risk
-                );
+            let rw = entries
+                .iter()
+                .map(|e| e.suggested_rule.len())
+                .chain(std::iter::once("Rule".len()))
+                .max()
+                .unwrap_or(20);
+
+            let mut out = String::new();
+            let sep = format!("{:-<9}  {:->5}  {:->8}  {:-<rw$}", "", "", "", "");
+
+            writeln!(out, "{:<9}  {:>5}  {:>8}  {}", "Risk", "Count", "Sessions", "Rule").unwrap();
+            writeln!(out, "{sep}").unwrap();
+
+            for e in &claude_entries {
+                writeln!(out, "{:<9}  {:>5}  {:>8}  {}", e.risk, e.count, e.sessions, e.suggested_rule).unwrap();
             }
+
+            if !claude_entries.is_empty() && !system_entries.is_empty() {
+                writeln!(out, "{sep}").unwrap();
+            }
+
+            for e in &system_entries {
+                writeln!(out, "{:<9}  {:>5}  {:>8}  {}", e.risk, e.count, e.sessions, e.suggested_rule).unwrap();
+            }
+
+            page_output(&out, pager);
         }
     }
 
@@ -243,19 +243,6 @@ mod tests {
             make_rule("mcp__atlassian__getJiraIssue", "{}"),
             "mcp__atlassian__getJiraIssue"
         );
-    }
-
-    #[test]
-    fn truncate_short() {
-        assert_eq!(truncate("hello", 10), "hello");
-    }
-
-    #[test]
-    fn truncate_long() {
-        let s = "abcdefghijklmnop";
-        let result = truncate(s, 10);
-        assert_eq!(result, "abcdefg...");
-        assert_eq!(result.chars().count(), 10);
     }
 
     #[test]

--- a/src/cmd/suggest.rs
+++ b/src/cmd/suggest.rs
@@ -4,6 +4,7 @@ use eyre::Result;
 use serde::Serialize;
 
 use crate::db::EventStore;
+use crate::filter::filter_by_patterns;
 use crate::pager::page_output;
 use crate::risk::{RiskTier, classify_rule};
 
@@ -153,8 +154,9 @@ fn extract_domain(url: &str) -> Option<String> {
 }
 
 /// Run the suggest command with output formatting.
-pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, format: &str, pager: Option<&str>) -> Result<()> {
+pub fn run_suggest(store: &EventStore, threshold: u32, min_sessions: u32, patterns: &[String], format: &str, pager: Option<&str>) -> Result<()> {
     let entries = suggest(store, threshold, min_sessions)?;
+    let entries = filter_by_patterns(entries, patterns, |e| e.suggested_rule.as_str());
 
     if entries.is_empty() {
         println!("No patterns meet the threshold ({threshold} observations, {min_sessions} sessions).");

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub extra_deny_patterns: Vec<String>,
     /// Risk tier overrides: map from pattern to tier name.
     pub risk_overrides: std::collections::HashMap<String, String>,
+    /// Pager command for paginated output (e.g. "less -F -X"). None disables paging.
+    pub pager: Option<String>,
 }
 
 impl Default for Config {
@@ -29,6 +31,7 @@ impl Default for Config {
             enforce_deny: true,
             extra_deny_patterns: Vec::new(),
             risk_overrides: std::collections::HashMap::new(),
+            pager: None,
         }
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -19,7 +19,8 @@ where
             .collect()
     };
 
-    let levels: [Box<dyn Fn(&str, &str) -> bool>; 3] = [
+    type Matcher = Box<dyn Fn(&str, &str) -> bool>;
+    let levels: [Matcher; 3] = [
         Box::new(|k: &str, p: &str| k == p),
         Box::new(|k: &str, p: &str| k.starts_with(p)),
         Box::new(|k: &str, p: &str| k.contains(p)),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,91 @@
+/// Filter items by patterns using cascading match: exact -> prefix -> substring.
+///
+/// - Empty patterns returns all items unchanged.
+/// - Otherwise tries each level in order; returns the first non-empty result set.
+pub fn filter_by_patterns<T, F>(items: Vec<T>, patterns: &[String], key: F) -> Vec<T>
+where
+    F: Fn(&T) -> &str,
+{
+    if patterns.is_empty() {
+        return items;
+    }
+
+    let matched_indices = |f: &dyn Fn(&str, &str) -> bool| -> Vec<usize> {
+        items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| patterns.iter().any(|p| f(key(item), p)))
+            .map(|(i, _)| i)
+            .collect()
+    };
+
+    let levels: [Box<dyn Fn(&str, &str) -> bool>; 3] = [
+        Box::new(|k: &str, p: &str| k == p),
+        Box::new(|k: &str, p: &str| k.starts_with(p)),
+        Box::new(|k: &str, p: &str| k.contains(p)),
+    ];
+
+    for level in &levels {
+        let indices = matched_indices(level.as_ref());
+        if !indices.is_empty() {
+            return items
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| indices.contains(i))
+                .map(|(_, item)| item)
+                .collect();
+        }
+    }
+
+    vec![]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_patterns_returns_all() {
+        let items = vec!["foo", "bar", "baz"];
+        assert_eq!(filter_by_patterns(items, &[], |s| s), vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn exact_match_wins() {
+        let items = vec!["Bash(git status:*)", "Bash(git push:*)", "Bash(git:*)"];
+        let result = filter_by_patterns(items, &p(&["Bash(git status:*)"]), |s| s);
+        assert_eq!(result, vec!["Bash(git status:*)"]);
+    }
+
+    #[test]
+    fn prefix_match_when_no_exact() {
+        let items = vec!["Bash(git status:*)", "Bash(git push:*)", "WebSearch", "Edit(**)"];
+        let result = filter_by_patterns(items, &p(&["Bash"]), |s| s);
+        assert_eq!(result, vec!["Bash(git status:*)", "Bash(git push:*)"]);
+    }
+
+    #[test]
+    fn substring_match_when_no_prefix() {
+        let items = vec!["Bash(git status:*)", "Bash(git push:*)", "WebSearch"];
+        let result = filter_by_patterns(items, &p(&["git"]), |s| s);
+        assert_eq!(result, vec!["Bash(git status:*)", "Bash(git push:*)"]);
+    }
+
+    #[test]
+    fn multiple_patterns_same_level() {
+        let items = vec!["Bash(git status:*)", "Bash(cargo build:*)", "WebSearch"];
+        let result = filter_by_patterns(items, &p(&["Bash(git status:*)", "Bash(cargo build:*)"]), |s| s);
+        assert_eq!(result, vec!["Bash(git status:*)", "Bash(cargo build:*)"]);
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        let items = vec!["foo", "bar"];
+        let result = filter_by_patterns(items, &p(&["zzz"]), |s| s);
+        assert!(result.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cmd;
 pub mod config;
 pub mod db;
+pub mod filter;
 pub mod hook;
 pub mod pager;
 pub mod risk;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cmd;
 pub mod config;
 pub mod db;
 pub mod hook;
+pub mod pager;
 pub mod risk;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,20 +95,22 @@ fn run() -> Result<()> {
             settings_local,
             format,
             risk,
+            patterns,
         } => {
             let sp = settings.unwrap_or_else(settings_path);
             let slp = settings_local.unwrap_or_else(settings_local_path);
             let risk_filter = risk.and_then(|r| claude_permit::risk::RiskTier::from_str_opt(&r));
-            cmd::run_audit(&sp, &slp, &format, risk_filter, config.pager.as_deref())?;
+            cmd::run_audit(&sp, &slp, &patterns, &format, risk_filter, config.pager.as_deref())?;
         }
         Command::Suggest {
             threshold,
             sessions,
             format,
+            patterns,
         } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_suggest(&store, threshold, sessions, &format, config.pager.as_deref())?;
+            cmd::run_suggest(&store, threshold, sessions, &patterns, &format, config.pager.as_deref())?;
         }
         Command::Report { session, format } => {
             let db_path = EventStore::default_path()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,12 +95,13 @@ fn run() -> Result<()> {
             settings_local,
             format,
             risk,
+            apply,
             patterns,
         } => {
             let sp = settings.unwrap_or_else(settings_path);
             let slp = settings_local.unwrap_or_else(settings_local_path);
             let risk_filter = risk.and_then(|r| claude_permit::risk::RiskTier::from_str_opt(&r));
-            cmd::run_audit(&sp, &slp, &patterns, &format, risk_filter, config.pager.as_deref())?;
+            cmd::run_audit(&sp, &slp, &patterns, &format, risk_filter, apply.as_deref(), config.pager.as_deref())?;
         }
         Command::Suggest {
             threshold,

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,15 @@ fn run() -> Result<()> {
             let sp = settings.unwrap_or_else(settings_path);
             let slp = settings_local.unwrap_or_else(settings_local_path);
             let risk_filter = risk.and_then(|r| claude_permit::risk::RiskTier::from_str_opt(&r));
-            cmd::run_audit(&sp, &slp, &patterns, &format, risk_filter, apply.as_deref(), config.pager.as_deref())?;
+            cmd::run_audit(
+                &sp,
+                &slp,
+                &patterns,
+                &format,
+                risk_filter,
+                apply.as_deref(),
+                config.pager.as_deref(),
+            )?;
         }
         Command::Suggest {
             threshold,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,10 +74,10 @@ fn run() -> Result<()> {
     setup_logging().context("Failed to setup logging")?;
 
     let cli = Cli::parse();
+    let config = Config::load(None).unwrap_or_default();
 
     match cli.command {
         Command::Log => {
-            let config = Config::load(None).unwrap_or_default();
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
             let result = cmd::run_log(&store, config.enforce_deny, &config.extra_deny_patterns)?;
@@ -99,7 +99,7 @@ fn run() -> Result<()> {
             let sp = settings.unwrap_or_else(settings_path);
             let slp = settings_local.unwrap_or_else(settings_local_path);
             let risk_filter = risk.and_then(|r| claude_permit::risk::RiskTier::from_str_opt(&r));
-            cmd::run_audit(&sp, &slp, &format, risk_filter)?;
+            cmd::run_audit(&sp, &slp, &format, risk_filter, config.pager.as_deref())?;
         }
         Command::Suggest {
             threshold,
@@ -108,12 +108,12 @@ fn run() -> Result<()> {
         } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_suggest(&store, threshold, sessions, &format)?;
+            cmd::run_suggest(&store, threshold, sessions, &format, config.pager.as_deref())?;
         }
         Command::Report { session, format } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_report(&store, session.as_deref(), &format)?;
+            cmd::run_report(&store, session.as_deref(), &format, config.pager.as_deref())?;
         }
         Command::Clean { older_than, dry_run } => {
             let db_path = EventStore::default_path()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,8 +140,9 @@ fn run() -> Result<()> {
             let do_promote = promote || all;
             let do_remove = remove || all;
             let do_deny = deny || all;
+            let do_dupe = all;
 
-            if !do_promote && !do_remove && !do_deny {
+            if !do_promote && !do_remove && !do_deny && !do_dupe {
                 eprintln!("No filter specified. Use --promote, --remove, --deny, or --all.");
                 std::process::exit(1);
             }
@@ -152,8 +153,9 @@ fn run() -> Result<()> {
                 promote: do_promote,
                 remove: do_remove,
                 deny: do_deny,
+                dupe: do_dupe,
             };
-            cmd::run_apply(&sp, &slp, &filter, yes, !no_backup)?;
+            claude_permit::cmd::apply::run_apply(&sp, &slp, &filter, yes, !no_backup)?;
         }
     }
 

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,0 +1,24 @@
+use std::io::{IsTerminal, Write};
+
+/// Send `text` through a pager when stdout is a terminal.
+/// Falls back to plain print if pager is unavailable or stdout is not a terminal.
+pub fn page_output(text: &str, pager: Option<&str>) {
+    let pager_cmd = pager.unwrap_or("less -R");
+    if std::io::stdout().is_terminal() {
+        let mut parts = pager_cmd.split_whitespace();
+        let cmd = parts.next().unwrap_or("less");
+        let args: Vec<&str> = parts.collect();
+        if let Ok(mut child) = std::process::Command::new(cmd)
+            .args(&args)
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+        {
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            let _ = child.wait();
+            return;
+        }
+    }
+    print!("{text}");
+}

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,23 +1,29 @@
 use std::io::{IsTerminal, Write};
+use terminal_size::{Height, terminal_size};
 
-/// Send `text` through a pager when stdout is a terminal.
-/// Falls back to plain print if pager is unavailable or stdout is not a terminal.
+/// Send `text` through a pager only when output exceeds the terminal height.
+/// Falls back to plain print if not a terminal, output fits, or pager is unavailable.
 pub fn page_output(text: &str, pager: Option<&str>) {
-    let pager_cmd = pager.unwrap_or("less -R");
     if std::io::stdout().is_terminal() {
-        let mut parts = pager_cmd.split_whitespace();
-        let cmd = parts.next().unwrap_or("less");
-        let args: Vec<&str> = parts.collect();
-        if let Ok(mut child) = std::process::Command::new(cmd)
-            .args(&args)
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-        {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(text.as_bytes());
+        let line_count = text.lines().count();
+        let term_height = terminal_size().map(|(_, Height(h))| h as usize).unwrap_or(24);
+
+        if line_count > term_height {
+            let pager_cmd = pager.unwrap_or("less -R");
+            let mut parts = pager_cmd.split_whitespace();
+            let cmd = parts.next().unwrap_or("less");
+            let args: Vec<&str> = parts.collect();
+            if let Ok(mut child) = std::process::Command::new(cmd)
+                .args(&args)
+                .stdin(std::process::Stdio::piped())
+                .spawn()
+            {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.write_all(text.as_bytes());
+                }
+                let _ = child.wait();
+                return;
             }
-            let _ = child.wait();
-            return;
         }
     }
     print!("{text}");

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -1,3 +1,3 @@
 mod tier;
 
-pub use tier::{Recommendation, RiskTier, classify_rule, classify_tool_input, matches_deny_list, recommend};
+pub use tier::{Recommendation, RiskTier, classify_rule, classify_tool_input, matches_deny_list, recommend, subsumes};

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -280,9 +280,12 @@ pub fn classify_rule(rule: &str) -> RiskTier {
         return RiskTier::Moderate;
     }
 
-    if rule == "Read" || rule == "Glob" || rule == "Grep"
-        || rule == "Read(**)" || rule == "Glob(**)" || rule == "Grep(**)"
-    {
+    // Bare Read or Read(**) is carte blanche filesystem access - moderate risk
+    if rule == "Read" || rule == "Read(**)" {
+        return RiskTier::Moderate;
+    }
+
+    if rule == "Glob" || rule == "Grep" || rule == "Glob(**)" || rule == "Grep(**)" {
         return RiskTier::Safe;
     }
 

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -12,11 +12,11 @@ pub enum RiskTier {
 
 impl fmt::Display for RiskTier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RiskTier::Safe => write!(f, "safe"),
-            RiskTier::Moderate => write!(f, "moderate"),
-            RiskTier::Dangerous => write!(f, "dangerous"),
-        }
+        f.pad(match self {
+            RiskTier::Safe => "safe",
+            RiskTier::Moderate => "moderate",
+            RiskTier::Dangerous => "dangerous",
+        })
     }
 }
 
@@ -44,13 +44,13 @@ pub enum Recommendation {
 
 impl fmt::Display for Recommendation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Recommendation::Promote => write!(f, "promote"),
-            Recommendation::Keep => write!(f, "keep"),
-            Recommendation::Narrow => write!(f, "narrow"),
-            Recommendation::Remove => write!(f, "remove"),
-            Recommendation::Deny => write!(f, "deny"),
-        }
+        f.pad(match self {
+            Recommendation::Promote => "promote",
+            Recommendation::Keep => "keep",
+            Recommendation::Narrow => "narrow",
+            Recommendation::Remove => "remove",
+            Recommendation::Deny => "deny",
+        })
     }
 }
 

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -73,9 +73,7 @@ pub fn subsumes(broad: &str, narrow: &str) -> bool {
 
     // File-tool subsumption: Tool(**) subsumes Tool(<anything else>)
     if let (Some((bt, bp)), Some((nt, np))) = (split_paren(broad), split_paren(narrow)) {
-        if bt == nt && bp == "**" && np != "**" {
-            return true;
-        }
+        return bt == nt && bp == "**" && np != "**";
     }
 
     false
@@ -618,8 +616,14 @@ mod tests {
 
     #[test]
     fn env_var_prefix_is_dangerous() {
-        assert_eq!(classify_rule("Bash(GH_TOKEN=\"$TOKEN\" gh pr view:*)"), RiskTier::Dangerous);
-        assert_eq!(classify_rule("Bash(GIT_SSH_COMMAND=\"ssh -i ~/.ssh/id\" git push:*)"), RiskTier::Dangerous);
+        assert_eq!(
+            classify_rule("Bash(GH_TOKEN=\"$TOKEN\" gh pr view:*)"),
+            RiskTier::Dangerous
+        );
+        assert_eq!(
+            classify_rule("Bash(GIT_SSH_COMMAND=\"ssh -i ~/.ssh/id\" git push:*)"),
+            RiskTier::Dangerous
+        );
         assert_eq!(classify_rule("Bash(API_KEY=\"abc\" curl:*)"), RiskTier::Dangerous);
     }
 

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -40,6 +40,7 @@ pub enum Recommendation {
     Narrow,
     Remove,
     Deny,
+    Dupe,
 }
 
 impl fmt::Display for Recommendation {
@@ -50,8 +51,43 @@ impl fmt::Display for Recommendation {
             Recommendation::Narrow => "narrow",
             Recommendation::Remove => "remove",
             Recommendation::Deny => "deny",
+            Recommendation::Dupe => "dupe",
         })
     }
+}
+
+/// Returns true if `broad` covers everything `narrow` covers — i.e., `narrow` is redundant.
+///
+/// Two cases:
+/// - Bash: `Bash(X:*)` subsumes `Bash(Y:*)` when Y starts with "X " (word-boundary prefix)
+/// - File tools: `Tool(**)` subsumes `Tool(<any other pattern>)`
+pub fn subsumes(broad: &str, narrow: &str) -> bool {
+    if broad == narrow {
+        return false;
+    }
+
+    // Bash subsumption: Bash(X:*) subsumes Bash(Y:*) when Y starts with "X "
+    if let (Some(bx), Some(ny)) = (extract_bash_pattern(broad), extract_bash_pattern(narrow)) {
+        return ny.starts_with(&format!("{bx} "));
+    }
+
+    // File-tool subsumption: Tool(**) subsumes Tool(<anything else>)
+    if let (Some((bt, bp)), Some((nt, np))) = (split_paren(broad), split_paren(narrow)) {
+        if bt == nt && bp == "**" && np != "**" {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Split "Tool(pattern)" into ("Tool", "pattern"), or None.
+fn split_paren(rule: &str) -> Option<(&str, &str)> {
+    let i = rule.find('(')?;
+    if !rule.ends_with(')') {
+        return None;
+    }
+    Some((&rule[..i], &rule[i + 1..rule.len() - 1]))
 }
 
 /// Patterns that should always be denied.
@@ -310,6 +346,21 @@ fn classify_bash_command(cmd: &str) -> RiskTier {
         return RiskTier::Dangerous;
     }
 
+    // Env var assignments (e.g. GH_TOKEN="..." cmd) are one-time specific invocations
+    if starts_with_env_var(cmd) {
+        return RiskTier::Dangerous;
+    }
+
+    // git -C <path> is a path-locked invocation that shouldn't be permanently allowed
+    if cmd.starts_with("git -C ") {
+        return RiskTier::Dangerous;
+    }
+
+    // bash -c is an arbitrary shell escape and should not be permanently allowed
+    if cmd.starts_with("bash -c") {
+        return RiskTier::Dangerous;
+    }
+
     // Check safe commands (longest prefix match)
     if matches_command_list(cmd, SAFE_BASH_COMMANDS) {
         return RiskTier::Safe;
@@ -322,6 +373,24 @@ fn classify_bash_command(cmd: &str) -> RiskTier {
 
     // Unknown command - default to moderate
     RiskTier::Moderate
+}
+
+/// Returns true if the command starts with a shell env var assignment (e.g. `FOO=bar cmd`).
+fn starts_with_env_var(cmd: &str) -> bool {
+    // Match VAR= or VAR="..." at the start, where VAR is [A-Z_][A-Z0-9_]*
+    let bytes = cmd.as_bytes();
+    let mut i = 0;
+    // Must start with an uppercase letter or underscore
+    if i >= bytes.len() || !(bytes[i].is_ascii_uppercase() || bytes[i] == b'_') {
+        return false;
+    }
+    i += 1;
+    // Consume rest of VAR name
+    while i < bytes.len() && (bytes[i].is_ascii_uppercase() || bytes[i].is_ascii_digit() || bytes[i] == b'_') {
+        i += 1;
+    }
+    // Must be followed by '='
+    i < bytes.len() && bytes[i] == b'='
 }
 
 fn classify_mcp_tool(tool: &str) -> RiskTier {
@@ -540,5 +609,51 @@ mod tests {
     #[test]
     fn not_broad_specific_git() {
         assert!(!is_overly_broad("Bash(git status:*)"));
+    }
+
+    // --- Env var prefix tests ---
+
+    #[test]
+    fn env_var_prefix_is_dangerous() {
+        assert_eq!(classify_rule("Bash(GH_TOKEN=\"$TOKEN\" gh pr view:*)"), RiskTier::Dangerous);
+        assert_eq!(classify_rule("Bash(GIT_SSH_COMMAND=\"ssh -i ~/.ssh/id\" git push:*)"), RiskTier::Dangerous);
+        assert_eq!(classify_rule("Bash(API_KEY=\"abc\" curl:*)"), RiskTier::Dangerous);
+    }
+
+    #[test]
+    fn lowercase_var_is_not_env_var() {
+        // lowercase assignments are not detected (conservative)
+        assert_ne!(classify_rule("Bash(foo=bar cmd:*)"), RiskTier::Dangerous);
+    }
+
+    #[test]
+    fn starts_with_env_var_fn() {
+        assert!(starts_with_env_var("GH_TOKEN=\"x\" cmd"));
+        assert!(starts_with_env_var("GIT_SSH_COMMAND=ssh git"));
+        assert!(starts_with_env_var("_VAR=1 cmd"));
+        assert!(!starts_with_env_var("git status"));
+        assert!(!starts_with_env_var("gh pr view"));
+    }
+
+    // --- git -C tests ---
+
+    #[test]
+    fn git_dash_c_is_dangerous() {
+        assert_eq!(classify_rule("Bash(git -C /some/path push:*)"), RiskTier::Dangerous);
+        assert_eq!(classify_rule("Bash(git -C ~/repos/foo status:*)"), RiskTier::Dangerous);
+    }
+
+    #[test]
+    fn git_without_dash_c_not_affected() {
+        assert_eq!(classify_rule("Bash(git status:*)"), RiskTier::Safe);
+        assert_eq!(classify_rule("Bash(git push:*)"), RiskTier::Moderate);
+    }
+
+    // --- bash -c tests ---
+
+    #[test]
+    fn bash_dash_c_is_dangerous() {
+        assert_eq!(classify_rule("Bash(bash -c 'echo hi':*)"), RiskTier::Dangerous);
+        assert_eq!(classify_rule("Bash(bash -c:*)"), RiskTier::Dangerous);
     }
 }

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -236,8 +236,18 @@ pub fn classify_rule(rule: &str) -> RiskTier {
         return classify_bash_command(inner);
     }
 
+    if rule == "Edit" || rule == "Write" || rule == "Edit(**)" || rule == "Write(**)" {
+        return RiskTier::Dangerous;
+    }
+
     if rule.starts_with("Edit(") || rule.starts_with("Write(") {
         return RiskTier::Moderate;
+    }
+
+    if rule == "Read" || rule == "Glob" || rule == "Grep"
+        || rule == "Read(**)" || rule == "Glob(**)" || rule == "Grep(**)"
+    {
+        return RiskTier::Safe;
     }
 
     if rule.starts_with("Read(") || rule.starts_with("Glob(") || rule.starts_with("Grep(") {


### PR DESCRIPTION
## Summary

- Recovers 6 commits that were mistakenly pushed to `scottidler/claude-permit` instead of here:
  - `fix(suggest,apply)`: global allows for file tools; skip deny-list rules in apply
  - `refactor(audit,suggest)`: rename Recommendation->Action, unify column order
  - `feat(audit,suggest,pager)`: pattern filtering, dupe rename, dangerous rule detection, smart pager
  - `refactor(audit)`: replace apply subcommand with `--apply` flag on audit
  - `fix(risk)`: classify `Read(**)` and bare Read as moderate, not safe
  - `feat`: add install.sh and curl install instructions to README
- Discards the old `add-install-script` branch and rebuilds it cleanly on top of all recovered commits
- Rewrites README from scratch with complete documentation: all commands, flags, risk tiers, config, and tips - install-first layout modeled after claude-cost-usage

## Test plan

- [ ] `cargo build` passes
- [ ] `claude-permit audit` outputs correct table
- [ ] `claude-permit suggest` works with threshold flags
- [ ] `claude-permit install --yes` registers hook
- [ ] `claude-permit check` passes after install