### PR TITLE
fix(deny): remove rkvr reference and broaden rm deny to all variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ These are blocked at hook time (when `enforce-deny: true`) and flagged in audit 
 - `git tag -d` - local tag deletion
 - `git push * :refs/tags/` - remote tag deletion via refspec
 - `git push * --delete * tag` - remote tag deletion via `--delete`
-- `rm -rf` and `rm -r ` - recursive removal (use `rkvr rmrf` instead)
+- `rm -rf` and `rm -r ` - recursive removal (dangerous, permanently denied)
 - `cd && ` - compound cd with `&&`
 
 ### Automatic Dangerous Rule Detection

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -78,8 +78,8 @@ pub fn run_log(store: &EventStore, enforce_deny: bool, extra_deny_patterns: &[St
 }
 
 fn deny_reason(cmd: &str) -> String {
-    if cmd.starts_with("rm -rf") || cmd.starts_with("rm -r ") {
-        format!("'{cmd}' is permanently denied; use 'rkvr rmrf' instead")
+    if cmd.starts_with("rm ") {
+        format!("'{cmd}' is permanently denied; rm is dangerous")
     } else if cmd.starts_with("cd ") && cmd.contains("&&") {
         format!("'{cmd}' is permanently denied; compound cd commands are a security risk")
     } else if cmd.starts_with("git tag -d") {
@@ -111,9 +111,9 @@ mod tests {
     }
 
     #[test]
-    fn deny_reason_rm_rf() {
-        let reason = deny_reason("rm -rf /tmp");
-        assert!(reason.contains("rkvr rmrf"));
+    fn deny_reason_rm() {
+        assert!(deny_reason("rm -rf /tmp").contains("rm is dangerous"));
+        assert!(deny_reason("rm /tmp/file").contains("rm is dangerous"));
     }
 
     #[test]

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -93,8 +93,7 @@ const PERMANENT_DENY: &[&str] = &[
     "git tag -d",
     "git push * :refs/tags/",
     "git push * --delete * tag",
-    "rm -rf",
-    "rm -r ",
+    "rm ",
     "cd &&",
 ];
 
@@ -258,7 +257,6 @@ const MODERATE_BASH_COMMANDS: &[&str] = &[
     "pipx",
     "npm",
     "pnpm",
-    "rkvr rmrf",
     "gh pr create",
     "curl",
 ];
@@ -452,14 +450,11 @@ mod tests {
     // --- Deny list tests ---
 
     #[test]
-    fn deny_rm_rf() {
+    fn deny_rm() {
         assert!(matches_deny_list("rm -rf /tmp"));
-        assert!(matches_deny_list("rm -rf"));
-    }
-
-    #[test]
-    fn deny_rm_r() {
         assert!(matches_deny_list("rm -r /tmp"));
+        assert!(matches_deny_list("rm /tmp/file"));
+        assert!(matches_deny_list("rm -f /tmp/file"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove personal-tool name (`rkvr`) from deny error messages; use generic wording instead
- Expand the `rm` deny rule from `-rf`/`-r ` only to all `rm` invocations
- Update README, `deny_reason` in `cmd/log.rs`, and `PERMANENT_DENY` in `risk/tier.rs`

## Test plan

- [ ] `cargo test` passes with updated `deny_rm` and `deny_reason_rm` tests
- [ ] `deny_reason("rm /tmp/file")` returns a generic message with no personal tool references
- [ ] `matches_deny_list("rm /tmp/file")` returns true