### PR TITLE
feat(config): make all deny/classification rules configurable via XDG config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-permit"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-permit"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ These are blocked at hook time (when `enforce-deny: true`) and flagged in audit 
 - `git tag -d` - local tag deletion
 - `git push * :refs/tags/` - remote tag deletion via refspec
 - `git push * --delete * tag` - remote tag deletion via `--delete`
-- `rm -rf` and `rm -r ` - recursive removal (use `rkvr rmrf` instead)
+- `rm -rf` and `rm -r ` - recursive removal (dangerous, permanently denied)
 - `cd && ` - compound cd with `&&`
 
 ### Automatic Dangerous Rule Detection

--- a/claude-permit.yml
+++ b/claude-permit.yml
@@ -10,14 +10,66 @@ suggest-sessions: 2
 # Days after which events are eligible for cleanup
 clean-older-than: 90
 
-# Whether the log command should actively deny permanently-blocked patterns
-enforce-deny: true
+# Whether the log command should actively deny matched patterns.
+# Default: false (observe only). Set to true to enforce blocking.
+enforce-deny: false
 
-# Additional deny patterns beyond the built-in list
-# extra-deny-patterns:
-#   - "shutdown"
-#   - "reboot"
+# Bash patterns that are permanently denied when enforce-deny is true.
+# mode: extend (default) - add items to the built-in defaults
+# mode: replace - ignore defaults entirely and use only the items listed
+#
+# Built-in defaults:
+#   "git tag -d"                       - local tag deletion
+#   "git push * :refs/tags/"           - remote tag deletion
+#   "git push * --delete * tag"        - remote tag deletion (alt form)
+#   "rm "                              - any rm invocation
+#   "cd &&"                            - compound cd commands
+#
+# Example: add a pattern
+# deny-patterns:
+#   items:
+#     - "shutdown"
+#     - "reboot"
+#
+# Example: replace defaults entirely (only block what you specify)
+# deny-patterns:
+#   mode: replace
+#   items:
+#     - "rm "
 
-# Risk tier overrides (pattern -> tier)
-# risk-overrides:
-#   "cargo build": "safe"
+# Bash commands classified as safe risk.
+# Overriding these affects audit recommendations only, not enforcement.
+#
+# Example: add a custom tool to the safe list
+# safe-commands:
+#   items:
+#     - "mytool"
+
+# Bash commands classified as moderate risk.
+#
+# Example: replace the moderate list entirely
+# moderate-commands:
+#   mode: replace
+#   items:
+#     - "cargo"
+#     - "git commit"
+
+# MCP tools classified as dangerous (write/mutation operations).
+#
+# Example: add a service's write operations
+# mcp-write-tools:
+#   items:
+#     - "mcp__myservice__create_thing"
+#     - "mcp__myservice__delete_thing"
+
+# Rule patterns considered overly broad (triggers Narrow recommendation in audit).
+#
+# Built-in defaults: Bash(git:*), Bash(docker:*), Bash(sudo:*), Bash(yes:*)
+#
+# Example: add a broad pattern to flag
+# broad-patterns:
+#   items:
+#     - "Bash(mytool:*)"
+
+# Pager for long output. Set to "" or omit to disable paging.
+# pager: "less -F -X"

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use crate::cmd::audit::{AuditEntry, audit};
-use crate::risk::Recommendation;
+use crate::risk::{Recommendation, Rules};
 
 /// Which recommendation types to apply.
 pub struct ApplyFilter {
@@ -173,8 +173,9 @@ pub fn run_apply(
     filter: &ApplyFilter,
     write: bool,
     backup: bool,
+    rules: &Rules,
 ) -> Result<()> {
-    let entries = audit(settings_path, settings_local_path, &[], None)?;
+    let entries = audit(settings_path, settings_local_path, &[], None, rules)?;
     apply_entries(&entries, filter, settings_path, settings_local_path, backup, write)
 }
 
@@ -338,6 +339,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 
@@ -383,6 +385,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 
@@ -418,6 +421,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 
@@ -447,7 +451,7 @@ mod tests {
         let local_json = r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#;
         let (gp, lp) = write_settings(dir.path(), global_json, local_json);
 
-        run_apply(&gp, &lp, &ApplyFilter::all(), false, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter::all(), false, false, &Rules::default()).expect("apply");
 
         assert_eq!(std::fs::read_to_string(&gp).expect("read"), global_json);
         assert_eq!(std::fs::read_to_string(&lp).expect("read"), local_json);
@@ -473,6 +477,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 
@@ -505,6 +510,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 
@@ -521,7 +527,7 @@ mod tests {
             r#"{"permissions":{"allow":[]}}"#,
         );
 
-        run_apply(&gp, &lp, &ApplyFilter::all(), true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter::all(), true, false, &Rules::default()).expect("apply");
 
         let global: Value = serde_json::from_str(&std::fs::read_to_string(&gp).expect("read")).expect("parse");
         assert_eq!(
@@ -538,7 +544,7 @@ mod tests {
         let lp = dir.path().join("settings.local.json");
         std::fs::write(&gp, r#"{"permissions":{"allow":["Bash(ls:*)"]}}"#).expect("write");
 
-        run_apply(&gp, &lp, &ApplyFilter::all(), true, false).expect("apply");
+        run_apply(&gp, &lp, &ApplyFilter::all(), true, false, &Rules::default()).expect("apply");
     }
 
     #[test]
@@ -562,6 +568,7 @@ mod tests {
             },
             true,
             false,
+            &Rules::default(),
         )
         .expect("apply");
 

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::cmd::apply::{apply_entries, parse_apply_filter};
 use crate::filter::filter_by_patterns;
 use crate::pager::page_output;
-use crate::risk::{Recommendation, RiskTier, classify_rule, recommend, subsumes};
+use crate::risk::{Recommendation, RiskTier, Rules, subsumes};
 use crate::settings::load_settings;
 
 /// A single row in the audit output.
@@ -24,14 +24,15 @@ pub fn audit(
     settings_local_path: &Path,
     patterns: &[String],
     risk_filter: Option<RiskTier>,
+    rules: &Rules,
 ) -> Result<Vec<AuditEntry>> {
-    let rules = load_settings(settings_path, settings_local_path)?;
-    let mut entries: Vec<AuditEntry> = rules
+    let loaded = load_settings(settings_path, settings_local_path)?;
+    let mut entries: Vec<AuditEntry> = loaded
         .into_iter()
         .map(|r| {
-            let tier = classify_rule(&r.rule);
+            let tier = rules.classify_rule(&r.rule);
             let source_str = r.source.to_string();
-            let rec = recommend(tier, &source_str, &r.rule);
+            let rec = rules.recommend(tier, &source_str, &r.rule);
             AuditEntry {
                 rule: r.rule,
                 list: r.list.to_string(),
@@ -120,8 +121,9 @@ pub fn run_audit(
     risk_filter: Option<RiskTier>,
     apply: Option<&[String]>,
     pager: Option<&str>,
+    rules: &Rules,
 ) -> Result<()> {
-    let entries = audit(settings_path, settings_local_path, patterns, risk_filter)?;
+    let entries = audit(settings_path, settings_local_path, patterns, risk_filter, rules)?;
 
     match format {
         "json" => println!("{}", format_json(&entries)?),
@@ -177,7 +179,7 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn write_settings(dir: &Path, global: &str, local: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    fn write_settings(dir: &std::path::Path, global: &str, local: &str) -> (std::path::PathBuf, std::path::PathBuf) {
         let gp = dir.join("settings.json");
         let lp = dir.join("settings.local.json");
         std::fs::write(&gp, global).expect("write global");
@@ -194,7 +196,8 @@ mod tests {
             r#"{"permissions":{"allow":["Bash(sudo rm:*)","WebSearch"]}}"#,
         );
 
-        let entries = audit(&gp, &lp, &[], None).expect("audit");
+        let rules = Rules::default();
+        let entries = audit(&gp, &lp, &[], None, &rules).expect("audit");
         assert_eq!(entries.len(), 5);
 
         // ls is safe
@@ -221,7 +224,8 @@ mod tests {
             r#"{"permissions":{}}"#,
         );
 
-        let entries = audit(&gp, &lp, &[], Some(RiskTier::Dangerous)).expect("audit");
+        let rules = Rules::default();
+        let entries = audit(&gp, &lp, &[], Some(RiskTier::Dangerous), &rules).expect("audit");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].rule, "Bash(sudo rm:*)");
     }
@@ -270,7 +274,8 @@ mod tests {
             r#"{"permissions":{}}"#,
         );
 
-        let entries = audit(&gp, &lp, &[], None).expect("audit");
+        let rules = Rules::default();
+        let entries = audit(&gp, &lp, &[], None, &rules).expect("audit");
         assert_eq!(entries[0].recommendation, Recommendation::Narrow);
     }
 
@@ -284,7 +289,8 @@ mod tests {
             r#"{"permissions":{}}"#,
         );
 
-        let entries = audit(&gp, &lp, &[], None).expect("audit");
+        let rules = Rules::default();
+        let entries = audit(&gp, &lp, &[], None, &rules).expect("audit");
 
         let edit_specific = entries
             .iter()

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -60,10 +60,8 @@ pub fn run_log(store: &EventStore, rules: &Rules) -> Result<LogResult> {
     )?;
 
     // Check deny enforcement
-    if rules.enforce_deny && payload.tool_name == "Bash" {
-        if rules.matches_deny_list(&normalized) {
-            return Ok(LogResult::Deny(deny_reason(&normalized)));
-        }
+    if rules.enforce_deny && payload.tool_name == "Bash" && rules.matches_deny_list(&normalized) {
+        return Ok(LogResult::Deny(deny_reason(&normalized)));
     }
 
     Ok(LogResult::Passthrough)

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -122,8 +122,8 @@ mod tests {
 
     #[test]
     fn log_inserts_event_with_tier() {
-        use crate::hook::normalize_tool_input;
         use crate::hook::HookPayload;
+        use crate::hook::normalize_tool_input;
 
         let dir = tempfile::TempDir::new().expect("temp dir");
         let store = EventStore::open(&dir.path().join("test.db")).expect("open");

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 
 use crate::db::EventStore;
 use crate::hook::{HookPayload, normalize_tool_input};
-use crate::risk::{classify_tool_input, matches_deny_list};
+use crate::risk::Rules;
 
 /// The result of running the log command - either passthrough or deny.
 pub enum LogResult {
@@ -35,9 +35,9 @@ impl LogResult {
 
 /// Run the `log` subcommand: read hook JSON from stdin, write event to DB.
 ///
-/// If `enforce_deny` is true and the command matches a permanent deny pattern,
+/// If `rules.enforce_deny` is true and the command matches a deny pattern,
 /// returns a Deny result instead of Passthrough.
-pub fn run_log(store: &EventStore, enforce_deny: bool, extra_deny_patterns: &[String]) -> Result<LogResult> {
+pub fn run_log(store: &EventStore, rules: &Rules) -> Result<LogResult> {
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
 
@@ -47,7 +47,7 @@ pub fn run_log(store: &EventStore, enforce_deny: bool, extra_deny_patterns: &[St
     let raw_input = serde_json::to_string(&payload.tool_input)?;
     let session_id = payload.session_id.as_deref().unwrap_or("unknown");
     let timestamp = chrono::Utc::now().to_rfc3339();
-    let tier = classify_tool_input(&payload.tool_name, &normalized);
+    let tier = rules.classify_tool_input(&payload.tool_name, &normalized);
 
     store.insert_event(
         &timestamp,
@@ -60,17 +60,9 @@ pub fn run_log(store: &EventStore, enforce_deny: bool, extra_deny_patterns: &[St
     )?;
 
     // Check deny enforcement
-    if enforce_deny && payload.tool_name == "Bash" {
-        if matches_deny_list(&normalized) {
+    if rules.enforce_deny && payload.tool_name == "Bash" {
+        if rules.matches_deny_list(&normalized) {
             return Ok(LogResult::Deny(deny_reason(&normalized)));
-        }
-        // Check extra patterns from config
-        for pattern in extra_deny_patterns {
-            if normalized.starts_with(pattern.as_str()) {
-                return Ok(LogResult::Deny(format!(
-                    "'{normalized}' matches configured deny pattern '{pattern}'"
-                )));
-            }
         }
     }
 
@@ -130,8 +122,12 @@ mod tests {
 
     #[test]
     fn log_inserts_event_with_tier() {
+        use crate::hook::normalize_tool_input;
+        use crate::hook::HookPayload;
+
         let dir = tempfile::TempDir::new().expect("temp dir");
         let store = EventStore::open(&dir.path().join("test.db")).expect("open");
+        let rules = Rules::default();
 
         let json = r#"{"tool_name":"Bash","tool_input":{"command":"git status"},"session_id":"s1"}"#;
 
@@ -140,7 +136,7 @@ mod tests {
         let raw_input = serde_json::to_string(&payload.tool_input).expect("serialize");
         let session_id = payload.session_id.as_deref().unwrap_or("unknown");
         let timestamp = chrono::Utc::now().to_rfc3339();
-        let tier = classify_tool_input(&payload.tool_name, &normalized);
+        let tier = rules.classify_tool_input(&payload.tool_name, &normalized);
 
         store
             .insert_event(

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -78,8 +78,8 @@ pub fn run_log(store: &EventStore, enforce_deny: bool, extra_deny_patterns: &[St
 }
 
 fn deny_reason(cmd: &str) -> String {
-    if cmd.starts_with("rm -rf") || cmd.starts_with("rm -r ") {
-        format!("'{cmd}' is permanently denied; use 'rkvr rmrf' instead")
+    if cmd.starts_with("rm ") {
+        format!("'{cmd}' is permanently denied; rm is dangerous")
     } else if cmd.starts_with("cd ") && cmd.contains("&&") {
         format!("'{cmd}' is permanently denied; compound cd commands are a security risk")
     } else if cmd.starts_with("git tag -d") {
@@ -111,9 +111,9 @@ mod tests {
     }
 
     #[test]
-    fn deny_reason_rm_rf() {
-        let reason = deny_reason("rm -rf /tmp");
-        assert!(reason.contains("rkvr rmrf"));
+    fn deny_reason_rm() {
+        assert!(deny_reason("rm -rf /tmp").contains("rm is dangerous"));
+        assert!(deny_reason("rm /tmp/file").contains("rm is dangerous"));
     }
 
     #[test]

--- a/src/cmd/report.rs
+++ b/src/cmd/report.rs
@@ -88,7 +88,13 @@ pub fn report(store: &EventStore, session_id: Option<&str>, rules: &Rules) -> Re
 }
 
 /// Run the report command with output formatting.
-pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str, pager: Option<&str>, rules: &Rules) -> Result<()> {
+pub fn run_report(
+    store: &EventStore,
+    session_id: Option<&str>,
+    format: &str,
+    pager: Option<&str>,
+    rules: &Rules,
+) -> Result<()> {
     let rep = report(store, session_id, rules)?;
 
     if rep.total_events == 0 {

--- a/src/cmd/report.rs
+++ b/src/cmd/report.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::db::EventStore;
 use crate::pager::page_output;
-use crate::risk::{RiskTier, classify_tool_input};
+use crate::risk::{RiskTier, Rules};
 
 /// Summary of a session's permission activity.
 #[derive(Debug, Serialize)]
@@ -31,7 +31,7 @@ pub struct DangerousEvent {
 }
 
 /// Generate a session report.
-pub fn report(store: &EventStore, session_id: Option<&str>) -> Result<SessionReport> {
+pub fn report(store: &EventStore, session_id: Option<&str>, rules: &Rules) -> Result<SessionReport> {
     let events = store.session_events(session_id)?;
 
     if events.is_empty() {
@@ -54,7 +54,7 @@ pub fn report(store: &EventStore, session_id: Option<&str>) -> Result<SessionRep
     let mut dangerous_events = Vec::new();
 
     for event in &events {
-        let tier = classify_tool_input(&event.tool_name, &event.tool_input);
+        let tier = rules.classify_tool_input(&event.tool_name, &event.tool_input);
         match tier {
             RiskTier::Safe => safe += 1,
             RiskTier::Moderate => moderate += 1,
@@ -88,8 +88,8 @@ pub fn report(store: &EventStore, session_id: Option<&str>) -> Result<SessionRep
 }
 
 /// Run the report command with output formatting.
-pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str, pager: Option<&str>) -> Result<()> {
-    let rep = report(store, session_id)?;
+pub fn run_report(store: &EventStore, session_id: Option<&str>, format: &str, pager: Option<&str>, rules: &Rules) -> Result<()> {
+    let rep = report(store, session_id, rules)?;
 
     if rep.total_events == 0 {
         println!("No events found for session {}.", rep.session_id);
@@ -137,7 +137,7 @@ mod tests {
     fn report_empty_session() {
         let dir = tempfile::TempDir::new().expect("temp");
         let store = EventStore::open(&dir.path().join("test.db")).expect("open");
-        let rep = report(&store, Some("nonexistent")).expect("report");
+        let rep = report(&store, Some("nonexistent"), &Rules::default()).expect("report");
         assert_eq!(rep.total_events, 0);
     }
 
@@ -164,7 +164,7 @@ mod tests {
             .insert_event("2026-03-24T12:02:00Z", "s1", "Bash", "sudo rm /tmp/x", None, None, None)
             .expect("insert");
 
-        let rep = report(&store, Some("s1")).expect("report");
+        let rep = report(&store, Some("s1"), &Rules::default()).expect("report");
         assert_eq!(rep.total_events, 3);
         assert_eq!(rep.safe_count, 1);
         assert_eq!(rep.moderate_count, 1);
@@ -185,7 +185,7 @@ mod tests {
             .insert_event("2026-03-24T12:00:00Z", "new", "Bash", "tree", None, None, None)
             .expect("insert");
 
-        let rep = report(&store, None).expect("report");
+        let rep = report(&store, None, &Rules::default()).expect("report");
         assert_eq!(rep.session_id, "new");
         assert_eq!(rep.total_events, 1);
     }

--- a/src/cmd/suggest.rs
+++ b/src/cmd/suggest.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::db::EventStore;
 use crate::filter::filter_by_patterns;
 use crate::pager::page_output;
-use crate::risk::{RiskTier, classify_rule};
+use crate::risk::{RiskTier, Rules};
 
 /// Internal Claude mechanics tools - not relevant for permission rules.
 const SKIP_TOOLS: &[&str] = &[
@@ -35,7 +35,7 @@ pub struct SuggestEntry {
 }
 
 /// Generate suggestions from the event database.
-pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32) -> Result<Vec<SuggestEntry>> {
+pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32, rules: &Rules) -> Result<Vec<SuggestEntry>> {
     let patterns = store.suggest_patterns(threshold, min_sessions)?;
 
     // Compute suggested rules, filtering noise tools.
@@ -45,7 +45,7 @@ pub fn suggest(store: &EventStore, threshold: u32, min_sessions: u32) -> Result<
         .filter(|p| !SKIP_TOOLS.contains(&p.tool_name.as_str()))
         .map(|p| {
             let suggested_rule = make_rule(&p.tool_name, &p.tool_input);
-            let risk = classify_rule(&suggested_rule);
+            let risk = rules.classify_rule(&suggested_rule);
             let pattern = format_pattern(&p.tool_name, &p.tool_input);
             (pattern, suggested_rule, p.count, p.sessions, risk)
         })
@@ -157,8 +157,9 @@ pub fn run_suggest(
     patterns: &[String],
     format: &str,
     pager: Option<&str>,
+    rules: &Rules,
 ) -> Result<()> {
-    let entries = suggest(store, threshold, min_sessions)?;
+    let entries = suggest(store, threshold, min_sessions, rules)?;
     let entries = filter_by_patterns(entries, patterns, |e| e.suggested_rule.as_str());
 
     if entries.is_empty() {
@@ -264,6 +265,7 @@ mod tests {
     fn suggest_deduplicates_bash_variants() {
         let dir = tempfile::TempDir::new().expect("temp");
         let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
+        let rules = Rules::default();
 
         // Two variants of "otto ci" with different flags, across enough sessions
         for i in 0..5 {
@@ -284,7 +286,7 @@ mod tests {
                 .expect("insert");
         }
 
-        let entries = suggest(&store, 3, 2).expect("suggest");
+        let entries = suggest(&store, 3, 2, &rules).expect("suggest");
         // Both variants normalize to Bash(otto ci:*) - should be one entry
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].suggested_rule, "Bash(otto ci:*)");
@@ -295,6 +297,7 @@ mod tests {
     fn suggest_filters_task_tools() {
         let dir = tempfile::TempDir::new().expect("temp");
         let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
+        let rules = Rules::default();
 
         for i in 0..5 {
             let session = format!("s{i}");
@@ -311,7 +314,7 @@ mod tests {
                 .expect("insert");
         }
 
-        let entries = suggest(&store, 3, 2).expect("suggest");
+        let entries = suggest(&store, 3, 2, &rules).expect("suggest");
         assert!(entries.is_empty(), "TaskUpdate should be filtered out");
     }
 
@@ -319,6 +322,7 @@ mod tests {
     fn suggest_with_db() {
         let dir = tempfile::TempDir::new().expect("temp");
         let store = crate::db::EventStore::open(&dir.path().join("test.db")).expect("open");
+        let rules = Rules::default();
 
         for i in 0..5 {
             let session = format!("s{}", i % 3);
@@ -335,7 +339,7 @@ mod tests {
                 .expect("insert");
         }
 
-        let entries = suggest(&store, 3, 2).expect("suggest");
+        let entries = suggest(&store, 3, 2, &rules).expect("suggest");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].pattern, "git status");
         assert_eq!(entries[0].count, 5);

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,11 +123,7 @@ mod tests {
     fn load_from_yaml() {
         let dir = TempDir::new().expect("temp");
         let path = dir.path().join("config.yml");
-        std::fs::write(
-            &path,
-            "suggest-threshold: 5\nsuggest-sessions: 3\nenforce-deny: true\n",
-        )
-        .expect("write");
+        std::fs::write(&path, "suggest-threshold: 5\nsuggest-sessions: 3\nenforce-deny: true\n").expect("write");
 
         let config = Config::load(Some(&path)).expect("load");
         assert_eq!(config.suggest_threshold, 5);
@@ -180,11 +176,7 @@ mod tests {
     fn list_config_replace_mode() {
         let dir = TempDir::new().expect("temp");
         let path = dir.path().join("config.yml");
-        std::fs::write(
-            &path,
-            "deny-patterns:\n  mode: replace\n  items:\n    - \"rm \"\n",
-        )
-        .expect("write");
+        std::fs::write(&path, "deny-patterns:\n  mode: replace\n  items:\n    - \"rm \"\n").expect("write");
 
         let config = Config::load(Some(&path)).expect("load");
         assert_eq!(config.deny_patterns.mode, ListMode::Replace);

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,25 @@ use eyre::{Context, Result};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+/// How to combine user-specified items with the built-in defaults.
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ListMode {
+    /// Append user items after the built-in defaults.
+    #[default]
+    Extend,
+    /// Ignore defaults entirely; use only user items.
+    Replace,
+}
+
+/// A configurable list that can either extend or replace the built-in defaults.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ListConfig {
+    pub mode: ListMode,
+    pub items: Vec<String>,
+}
+
 /// Configuration for claude-permit, loaded from YAML.
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
@@ -12,12 +31,18 @@ pub struct Config {
     pub suggest_sessions: u32,
     /// Days after which events are eligible for cleanup.
     pub clean_older_than: u32,
-    /// Whether the log command should enforce deny patterns.
+    /// Whether the log command should enforce deny patterns. Default: false.
     pub enforce_deny: bool,
-    /// Additional deny patterns beyond the built-in list.
-    pub extra_deny_patterns: Vec<String>,
-    /// Risk tier overrides: map from pattern to tier name.
-    pub risk_overrides: std::collections::HashMap<String, String>,
+    /// Bash patterns that are permanently denied (blocks execution).
+    pub deny_patterns: ListConfig,
+    /// Bash commands classified as safe risk.
+    pub safe_commands: ListConfig,
+    /// Bash commands classified as moderate risk.
+    pub moderate_commands: ListConfig,
+    /// MCP tools classified as dangerous (write/mutation operations).
+    pub mcp_write_tools: ListConfig,
+    /// Rule patterns considered overly broad (triggers Narrow recommendation).
+    pub broad_patterns: ListConfig,
     /// Pager command for paginated output (e.g. "less -F -X"). None disables paging.
     pub pager: Option<String>,
 }
@@ -28,9 +53,12 @@ impl Default for Config {
             suggest_threshold: 3,
             suggest_sessions: 2,
             clean_older_than: 90,
-            enforce_deny: true,
-            extra_deny_patterns: Vec::new(),
-            risk_overrides: std::collections::HashMap::new(),
+            enforce_deny: false,
+            deny_patterns: ListConfig::default(),
+            safe_commands: ListConfig::default(),
+            moderate_commands: ListConfig::default(),
+            mcp_write_tools: ListConfig::default(),
+            broad_patterns: ListConfig::default(),
             pager: None,
         }
     }
@@ -88,7 +116,7 @@ mod tests {
         assert_eq!(config.suggest_threshold, 3);
         assert_eq!(config.suggest_sessions, 2);
         assert_eq!(config.clean_older_than, 90);
-        assert!(config.enforce_deny);
+        assert!(!config.enforce_deny);
     }
 
     #[test]
@@ -97,14 +125,14 @@ mod tests {
         let path = dir.path().join("config.yml");
         std::fs::write(
             &path,
-            "suggest-threshold: 5\nsuggest-sessions: 3\nenforce-deny: false\n",
+            "suggest-threshold: 5\nsuggest-sessions: 3\nenforce-deny: true\n",
         )
         .expect("write");
 
         let config = Config::load(Some(&path)).expect("load");
         assert_eq!(config.suggest_threshold, 5);
         assert_eq!(config.suggest_sessions, 3);
-        assert!(!config.enforce_deny);
+        assert!(config.enforce_deny);
     }
 
     #[test]
@@ -117,7 +145,7 @@ mod tests {
         assert_eq!(config.suggest_threshold, 10);
         // Others should be defaults
         assert_eq!(config.suggest_sessions, 2);
-        assert!(config.enforce_deny);
+        assert!(!config.enforce_deny);
     }
 
     #[test]
@@ -134,12 +162,43 @@ mod tests {
     }
 
     #[test]
-    fn extra_deny_patterns() {
+    fn list_config_extend_mode() {
         let dir = TempDir::new().expect("temp");
         let path = dir.path().join("config.yml");
-        std::fs::write(&path, "extra-deny-patterns:\n  - \"shutdown\"\n  - \"reboot\"\n").expect("write");
+        std::fs::write(
+            &path,
+            "deny-patterns:\n  mode: extend\n  items:\n    - \"shutdown\"\n    - \"reboot\"\n",
+        )
+        .expect("write");
 
         let config = Config::load(Some(&path)).expect("load");
-        assert_eq!(config.extra_deny_patterns, vec!["shutdown", "reboot"]);
+        assert_eq!(config.deny_patterns.mode, ListMode::Extend);
+        assert_eq!(config.deny_patterns.items, vec!["shutdown", "reboot"]);
+    }
+
+    #[test]
+    fn list_config_replace_mode() {
+        let dir = TempDir::new().expect("temp");
+        let path = dir.path().join("config.yml");
+        std::fs::write(
+            &path,
+            "deny-patterns:\n  mode: replace\n  items:\n    - \"rm \"\n",
+        )
+        .expect("write");
+
+        let config = Config::load(Some(&path)).expect("load");
+        assert_eq!(config.deny_patterns.mode, ListMode::Replace);
+        assert_eq!(config.deny_patterns.items, vec!["rm "]);
+    }
+
+    #[test]
+    fn list_config_items_only_defaults_to_extend() {
+        let dir = TempDir::new().expect("temp");
+        let path = dir.path().join("config.yml");
+        std::fs::write(&path, "deny-patterns:\n  items:\n    - \"custom\"\n").expect("write");
+
+        let config = Config::load(Some(&path)).expect("load");
+        assert_eq!(config.deny_patterns.mode, ListMode::Extend);
+        assert_eq!(config.deny_patterns.items, vec!["custom"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,15 @@ fn run() -> Result<()> {
         } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_suggest(&store, threshold, sessions, &patterns, &format, config.pager.as_deref(), &rules)?;
+            cmd::run_suggest(
+                &store,
+                threshold,
+                sessions,
+                &patterns,
+                &format,
+                config.pager.as_deref(),
+                &rules,
+            )?;
         }
         Command::Report { session, format } => {
             let db_path = EventStore::default_path()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod cli;
 use claude_permit::cmd;
 use claude_permit::config::Config;
 use claude_permit::db::EventStore;
+use claude_permit::risk::Rules;
 use cli::{Cli, Command};
 
 fn setup_logging() -> Result<()> {
@@ -75,12 +76,13 @@ fn run() -> Result<()> {
 
     let cli = Cli::parse();
     let config = Config::load(None).unwrap_or_default();
+    let rules = Rules::from_config(&config);
 
     match cli.command {
         Command::Log => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            let result = cmd::run_log(&store, config.enforce_deny, &config.extra_deny_patterns)?;
+            let result = cmd::run_log(&store, &rules)?;
             print!("{}", result.to_json());
         }
         Command::Check => {
@@ -109,6 +111,7 @@ fn run() -> Result<()> {
                 risk_filter,
                 apply.as_deref(),
                 config.pager.as_deref(),
+                &rules,
             )?;
         }
         Command::Suggest {
@@ -119,12 +122,12 @@ fn run() -> Result<()> {
         } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_suggest(&store, threshold, sessions, &patterns, &format, config.pager.as_deref())?;
+            cmd::run_suggest(&store, threshold, sessions, &patterns, &format, config.pager.as_deref(), &rules)?;
         }
         Command::Report { session, format } => {
             let db_path = EventStore::default_path()?;
             let store = EventStore::open(&db_path)?;
-            cmd::run_report(&store, session.as_deref(), &format, config.pager.as_deref())?;
+            cmd::run_report(&store, session.as_deref(), &format, config.pager.as_deref(), &rules)?;
         }
         Command::Clean { older_than, dry_run } => {
             let db_path = EventStore::default_path()?;
@@ -163,7 +166,7 @@ fn run() -> Result<()> {
                 deny: do_deny,
                 dupe: do_dupe,
             };
-            claude_permit::cmd::apply::run_apply(&sp, &slp, &filter, yes, !no_backup)?;
+            claude_permit::cmd::apply::run_apply(&sp, &slp, &filter, yes, !no_backup, &rules)?;
         }
     }
 

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -1,3 +1,3 @@
 mod tier;
 
-pub use tier::{Recommendation, RiskTier, classify_rule, classify_tool_input, matches_deny_list, recommend, subsumes};
+pub use tier::{Recommendation, RiskTier, Rules, subsumes};

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -216,12 +216,7 @@ const DEFAULT_MODERATE_BASH_COMMANDS: &[&str] = &[
 ];
 
 /// Default overly broad patterns (triggers Narrow recommendation).
-const DEFAULT_BROAD_PATTERNS: &[&str] = &[
-    "Bash(git:*)",
-    "Bash(docker:*)",
-    "Bash(sudo:*)",
-    "Bash(yes:*)",
-];
+const DEFAULT_BROAD_PATTERNS: &[&str] = &["Bash(git:*)", "Bash(docker:*)", "Bash(sudo:*)", "Bash(yes:*)"];
 
 // --- Rules ---
 
@@ -406,7 +401,11 @@ impl Rules {
 
     fn classify_mcp_tool(&self, tool: &str) -> RiskTier {
         let base = tool.split('(').next().unwrap_or(tool);
-        if self.mcp_write_tools.iter().any(|prefix| base.starts_with(prefix.as_str())) {
+        if self
+            .mcp_write_tools
+            .iter()
+            .any(|prefix| base.starts_with(prefix.as_str()))
+        {
             RiskTier::Dangerous
         } else {
             RiskTier::Moderate
@@ -458,9 +457,7 @@ fn starts_with_env_var(cmd: &str) -> bool {
 /// Check if a command matches any prefix in the given list.
 fn matches_command_list(cmd: &str, list: &[String]) -> bool {
     list.iter().any(|prefix| {
-        cmd == prefix.as_str()
-            || cmd.starts_with(&format!("{prefix} "))
-            || cmd.starts_with(&format!("{prefix}:"))
+        cmd == prefix.as_str() || cmd.starts_with(&format!("{prefix} ")) || cmd.starts_with(&format!("{prefix}:"))
     })
 }
 
@@ -660,13 +657,19 @@ mod tests {
     #[test]
     fn recommend_promote_safe_local() {
         let r = rules();
-        assert_eq!(r.recommend(RiskTier::Safe, "local", "Bash(ls:*)"), Recommendation::Promote);
+        assert_eq!(
+            r.recommend(RiskTier::Safe, "local", "Bash(ls:*)"),
+            Recommendation::Promote
+        );
     }
 
     #[test]
     fn recommend_keep_moderate_local() {
         let r = rules();
-        assert_eq!(r.recommend(RiskTier::Moderate, "local", "Bash(cargo:*)"), Recommendation::Keep);
+        assert_eq!(
+            r.recommend(RiskTier::Moderate, "local", "Bash(cargo:*)"),
+            Recommendation::Keep
+        );
     }
 
     #[test]
@@ -747,7 +750,10 @@ mod tests {
     fn git_dash_c_is_dangerous() {
         let r = rules();
         assert_eq!(r.classify_rule("Bash(git -C /some/path push:*)"), RiskTier::Dangerous);
-        assert_eq!(r.classify_rule("Bash(git -C ~/repos/foo status:*)"), RiskTier::Dangerous);
+        assert_eq!(
+            r.classify_rule("Bash(git -C ~/repos/foo status:*)"),
+            RiskTier::Dangerous
+        );
     }
 
     #[test]

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 use std::fmt;
 
+use crate::config::{Config, ListConfig, ListMode};
+
 /// Risk classification for a permission rule or tool invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -88,8 +90,10 @@ fn split_paren(rule: &str) -> Option<(&str, &str)> {
     Some((&rule[..i], &rule[i + 1..rule.len() - 1]))
 }
 
-/// Patterns that should always be denied.
-const PERMANENT_DENY: &[&str] = &[
+// --- Built-in defaults ---
+
+/// Default bash patterns that are permanently denied (blocks execution when enforce-deny is on).
+const DEFAULT_DENY: &[&str] = &[
     "git tag -d",
     "git push * :refs/tags/",
     "git push * --delete * tag",
@@ -97,58 +101,8 @@ const PERMANENT_DENY: &[&str] = &[
     "cd &&",
 ];
 
-/// Check if a command matches any permanent deny pattern.
-pub fn matches_deny_list(command: &str) -> bool {
-    let cmd = command.trim();
-    PERMANENT_DENY.iter().any(|pattern| {
-        if pattern.contains('*') {
-            glob_match(pattern, cmd)
-        } else if *pattern == "cd &&" {
-            // Special case: "cd && ..." or "cd <path> && ..."
-            cmd.starts_with("cd ") && cmd.contains("&&")
-        } else {
-            cmd.starts_with(pattern)
-        }
-    })
-}
-
-/// Simple glob matching: `*` matches any sequence of non-empty chars.
-fn glob_match(pattern: &str, text: &str) -> bool {
-    let parts: Vec<&str> = pattern.split('*').collect();
-    if parts.is_empty() {
-        return true;
-    }
-
-    let mut pos = 0;
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            continue;
-        }
-        if i == 0 {
-            // First part must match at start
-            if !text[pos..].starts_with(part) {
-                return false;
-            }
-            pos += part.len();
-        } else {
-            // Subsequent parts must appear after previous match
-            match text[pos..].find(part) {
-                Some(found) => {
-                    // Ensure at least one char was consumed by the wildcard
-                    if found == 0 {
-                        return false;
-                    }
-                    pos += found + part.len();
-                }
-                None => return false,
-            }
-        }
-    }
-    true
-}
-
-/// MCP tools that perform write/mutation operations.
-const MCP_WRITE_PREFIXES: &[&str] = &[
+/// Default MCP tools classified as dangerous (write/mutation operations).
+const DEFAULT_MCP_WRITE_PREFIXES: &[&str] = &[
     "mcp__slack__conversations_add_message",
     "mcp__atlassian__createJiraIssue",
     "mcp__atlassian__editJiraIssue",
@@ -166,8 +120,8 @@ const MCP_WRITE_PREFIXES: &[&str] = &[
     "mcp__multi-account-github__create_release",
 ];
 
-/// Read-only Bash commands (first word or "first second" prefix).
-const SAFE_BASH_COMMANDS: &[&str] = &[
+/// Default read-only Bash commands (first word or "first second" prefix).
+const DEFAULT_SAFE_BASH_COMMANDS: &[&str] = &[
     "ls",
     "tree",
     "stat",
@@ -229,8 +183,8 @@ const SAFE_BASH_COMMANDS: &[&str] = &[
     "gh run list",
 ];
 
-/// Moderate Bash commands (local writes, reversible).
-const MODERATE_BASH_COMMANDS: &[&str] = &[
+/// Default moderate Bash commands (local writes, reversible).
+const DEFAULT_MODERATE_BASH_COMMANDS: &[&str] = &[
     "git commit",
     "git push",
     "git add",
@@ -261,59 +215,219 @@ const MODERATE_BASH_COMMANDS: &[&str] = &[
     "curl",
 ];
 
-/// Classify a permission rule string like "Bash(git status:*)" or "Edit(src/**/*.rs)".
-pub fn classify_rule(rule: &str) -> RiskTier {
-    // Parse the rule format: Tool(pattern) or bare tool name
-    if let Some(inner) = extract_bash_pattern(rule) {
-        return classify_bash_command(inner);
-    }
+/// Default overly broad patterns (triggers Narrow recommendation).
+const DEFAULT_BROAD_PATTERNS: &[&str] = &[
+    "Bash(git:*)",
+    "Bash(docker:*)",
+    "Bash(sudo:*)",
+    "Bash(yes:*)",
+];
 
-    if rule == "Edit" || rule == "Write" || rule == "Edit(**)" || rule == "Write(**)" {
-        return RiskTier::Dangerous;
-    }
+// --- Rules ---
 
-    if rule.starts_with("Edit(") || rule.starts_with("Write(") {
-        return RiskTier::Moderate;
-    }
-
-    // Bare Read or Read(**) is carte blanche filesystem access - moderate risk
-    if rule == "Read" || rule == "Read(**)" {
-        return RiskTier::Moderate;
-    }
-
-    if rule == "Glob" || rule == "Grep" || rule == "Glob(**)" || rule == "Grep(**)" {
-        return RiskTier::Safe;
-    }
-
-    if rule.starts_with("Read(") || rule.starts_with("Glob(") || rule.starts_with("Grep(") {
-        return RiskTier::Safe;
-    }
-
-    if rule.starts_with("WebFetch(") || rule == "WebSearch" {
-        return RiskTier::Safe;
-    }
-
-    if rule.starts_with("Skill(") {
-        return RiskTier::Safe;
-    }
-
-    if rule.starts_with("mcp__") {
-        return classify_mcp_tool(rule);
-    }
-
-    // Unknown tool type - default to moderate
-    RiskTier::Moderate
+/// Resolved runtime rules, built from built-in defaults merged with user config.
+pub struct Rules {
+    pub enforce_deny: bool,
+    pub deny_patterns: Vec<String>,
+    pub safe_commands: Vec<String>,
+    pub moderate_commands: Vec<String>,
+    pub mcp_write_tools: Vec<String>,
+    pub broad_patterns: Vec<String>,
 }
 
-/// Classify a raw tool invocation (tool_name + tool_input).
-pub fn classify_tool_input(tool_name: &str, normalized_input: &str) -> RiskTier {
-    match tool_name {
-        "Bash" => classify_bash_command(normalized_input),
-        "Edit" | "Write" => RiskTier::Moderate,
-        "Read" | "Glob" | "Grep" => RiskTier::Safe,
-        "WebFetch" | "WebSearch" => RiskTier::Safe,
-        name if name.starts_with("mcp__") => classify_mcp_tool(name),
-        _ => RiskTier::Moderate,
+impl Default for Rules {
+    fn default() -> Self {
+        Self {
+            enforce_deny: false,
+            deny_patterns: DEFAULT_DENY.iter().map(|s| s.to_string()).collect(),
+            safe_commands: DEFAULT_SAFE_BASH_COMMANDS.iter().map(|s| s.to_string()).collect(),
+            moderate_commands: DEFAULT_MODERATE_BASH_COMMANDS.iter().map(|s| s.to_string()).collect(),
+            mcp_write_tools: DEFAULT_MCP_WRITE_PREFIXES.iter().map(|s| s.to_string()).collect(),
+            broad_patterns: DEFAULT_BROAD_PATTERNS.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl Rules {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            enforce_deny: config.enforce_deny,
+            deny_patterns: resolve_list(DEFAULT_DENY, &config.deny_patterns),
+            safe_commands: resolve_list(DEFAULT_SAFE_BASH_COMMANDS, &config.safe_commands),
+            moderate_commands: resolve_list(DEFAULT_MODERATE_BASH_COMMANDS, &config.moderate_commands),
+            mcp_write_tools: resolve_list(DEFAULT_MCP_WRITE_PREFIXES, &config.mcp_write_tools),
+            broad_patterns: resolve_list(DEFAULT_BROAD_PATTERNS, &config.broad_patterns),
+        }
+    }
+
+    /// Check if a command matches any deny pattern.
+    pub fn matches_deny_list(&self, command: &str) -> bool {
+        let cmd = command.trim();
+        self.deny_patterns.iter().any(|pattern| {
+            if pattern.contains('*') {
+                glob_match(pattern, cmd)
+            } else if pattern == "cd &&" {
+                // Special case: "cd <path> && ..." pattern
+                cmd.starts_with("cd ") && cmd.contains("&&")
+            } else {
+                cmd.starts_with(pattern.as_str())
+            }
+        })
+    }
+
+    /// Classify a permission rule string like "Bash(git status:*)" or "Edit(src/**/*.rs)".
+    pub fn classify_rule(&self, rule: &str) -> RiskTier {
+        if let Some(inner) = extract_bash_pattern(rule) {
+            return self.classify_bash_command(inner);
+        }
+
+        if rule == "Edit" || rule == "Write" || rule == "Edit(**)" || rule == "Write(**)" {
+            return RiskTier::Dangerous;
+        }
+
+        if rule.starts_with("Edit(") || rule.starts_with("Write(") {
+            return RiskTier::Moderate;
+        }
+
+        // Bare Read or Read(**) is carte blanche filesystem access - moderate risk
+        if rule == "Read" || rule == "Read(**)" {
+            return RiskTier::Moderate;
+        }
+
+        if rule == "Glob" || rule == "Grep" || rule == "Glob(**)" || rule == "Grep(**)" {
+            return RiskTier::Safe;
+        }
+
+        if rule.starts_with("Read(") || rule.starts_with("Glob(") || rule.starts_with("Grep(") {
+            return RiskTier::Safe;
+        }
+
+        if rule.starts_with("WebFetch(") || rule == "WebSearch" {
+            return RiskTier::Safe;
+        }
+
+        if rule.starts_with("Skill(") {
+            return RiskTier::Safe;
+        }
+
+        if rule.starts_with("mcp__") {
+            return self.classify_mcp_tool(rule);
+        }
+
+        // Unknown tool type - default to moderate
+        RiskTier::Moderate
+    }
+
+    /// Classify a raw tool invocation (tool_name + tool_input).
+    pub fn classify_tool_input(&self, tool_name: &str, normalized_input: &str) -> RiskTier {
+        match tool_name {
+            "Bash" => self.classify_bash_command(normalized_input),
+            "Edit" | "Write" => RiskTier::Moderate,
+            "Read" | "Glob" | "Grep" => RiskTier::Safe,
+            "WebFetch" | "WebSearch" => RiskTier::Safe,
+            name if name.starts_with("mcp__") => self.classify_mcp_tool(name),
+            _ => RiskTier::Moderate,
+        }
+    }
+
+    /// Determine recommendation for a rule given its risk tier and source.
+    pub fn recommend(&self, tier: RiskTier, source: &str, rule: &str) -> Recommendation {
+        // Permanently denied patterns
+        if let Some(cmd) = extract_bash_pattern(rule)
+            && self.matches_deny_list(cmd)
+        {
+            return Recommendation::Deny;
+        }
+
+        // Overly broad patterns
+        if self.is_overly_broad(rule) {
+            return Recommendation::Narrow;
+        }
+
+        match (tier, source) {
+            // Safe rules in local should be promoted to global
+            (RiskTier::Safe, "local") => Recommendation::Promote,
+            // Moderate rules in local - keep where they are
+            (RiskTier::Moderate, "local") => Recommendation::Keep,
+            // Dangerous rules in local - recommend removal
+            (RiskTier::Dangerous, "local") => Recommendation::Remove,
+            // Everything in global is already where it should be
+            (_, "global") => Recommendation::Keep,
+            _ => Recommendation::Keep,
+        }
+    }
+
+    fn classify_bash_command(&self, cmd: &str) -> RiskTier {
+        let cmd = cmd.trim();
+
+        // Check deny list first
+        if self.matches_deny_list(cmd) {
+            return RiskTier::Dangerous;
+        }
+
+        // sudo prefix is always dangerous
+        if cmd.starts_with("sudo ") {
+            return RiskTier::Dangerous;
+        }
+
+        // git push --force is dangerous
+        if cmd.starts_with("git push") && (cmd.contains("--force") || cmd.contains("-f")) {
+            return RiskTier::Dangerous;
+        }
+
+        // Env var assignments (e.g. GH_TOKEN="..." cmd) are one-time specific invocations
+        if starts_with_env_var(cmd) {
+            return RiskTier::Dangerous;
+        }
+
+        // git -C <path> is a path-locked invocation that shouldn't be permanently allowed
+        if cmd.starts_with("git -C ") {
+            return RiskTier::Dangerous;
+        }
+
+        // bash -c is an arbitrary shell escape and should not be permanently allowed
+        if cmd.starts_with("bash -c") {
+            return RiskTier::Dangerous;
+        }
+
+        // Check safe commands (longest prefix match)
+        if matches_command_list(cmd, &self.safe_commands) {
+            return RiskTier::Safe;
+        }
+
+        // Check moderate commands
+        if matches_command_list(cmd, &self.moderate_commands) {
+            return RiskTier::Moderate;
+        }
+
+        // Unknown command - default to moderate
+        RiskTier::Moderate
+    }
+
+    fn classify_mcp_tool(&self, tool: &str) -> RiskTier {
+        let base = tool.split('(').next().unwrap_or(tool);
+        if self.mcp_write_tools.iter().any(|prefix| base.starts_with(prefix.as_str())) {
+            RiskTier::Dangerous
+        } else {
+            RiskTier::Moderate
+        }
+    }
+
+    fn is_overly_broad(&self, rule: &str) -> bool {
+        self.broad_patterns.iter().any(|p| p == rule)
+    }
+}
+
+// --- Helpers ---
+
+fn resolve_list(defaults: &[&str], list_config: &ListConfig) -> Vec<String> {
+    match list_config.mode {
+        ListMode::Replace => list_config.items.clone(),
+        ListMode::Extend => {
+            let mut v: Vec<String> = defaults.iter().map(|s| s.to_string()).collect();
+            v.extend(list_config.items.iter().cloned());
+            v
+        }
     }
 }
 
@@ -327,206 +441,191 @@ fn extract_bash_pattern(rule: &str) -> Option<&str> {
     Some(inner.strip_suffix(":*").unwrap_or(inner))
 }
 
-fn classify_bash_command(cmd: &str) -> RiskTier {
-    let cmd = cmd.trim();
-
-    // Check permanent deny list first
-    if matches_deny_list(cmd) {
-        return RiskTier::Dangerous;
-    }
-
-    // sudo prefix is always dangerous
-    if cmd.starts_with("sudo ") {
-        return RiskTier::Dangerous;
-    }
-
-    // git push --force is dangerous
-    if cmd.starts_with("git push") && (cmd.contains("--force") || cmd.contains("-f")) {
-        return RiskTier::Dangerous;
-    }
-
-    // Env var assignments (e.g. GH_TOKEN="..." cmd) are one-time specific invocations
-    if starts_with_env_var(cmd) {
-        return RiskTier::Dangerous;
-    }
-
-    // git -C <path> is a path-locked invocation that shouldn't be permanently allowed
-    if cmd.starts_with("git -C ") {
-        return RiskTier::Dangerous;
-    }
-
-    // bash -c is an arbitrary shell escape and should not be permanently allowed
-    if cmd.starts_with("bash -c") {
-        return RiskTier::Dangerous;
-    }
-
-    // Check safe commands (longest prefix match)
-    if matches_command_list(cmd, SAFE_BASH_COMMANDS) {
-        return RiskTier::Safe;
-    }
-
-    // Check moderate commands
-    if matches_command_list(cmd, MODERATE_BASH_COMMANDS) {
-        return RiskTier::Moderate;
-    }
-
-    // Unknown command - default to moderate
-    RiskTier::Moderate
-}
-
 /// Returns true if the command starts with a shell env var assignment (e.g. `FOO=bar cmd`).
 fn starts_with_env_var(cmd: &str) -> bool {
-    // Match VAR= or VAR="..." at the start, where VAR is [A-Z_][A-Z0-9_]*
     let bytes = cmd.as_bytes();
     let mut i = 0;
-    // Must start with an uppercase letter or underscore
     if i >= bytes.len() || !(bytes[i].is_ascii_uppercase() || bytes[i] == b'_') {
         return false;
     }
     i += 1;
-    // Consume rest of VAR name
     while i < bytes.len() && (bytes[i].is_ascii_uppercase() || bytes[i].is_ascii_digit() || bytes[i] == b'_') {
         i += 1;
     }
-    // Must be followed by '='
     i < bytes.len() && bytes[i] == b'='
 }
 
-fn classify_mcp_tool(tool: &str) -> RiskTier {
-    // Strip any pattern suffix for matching
-    let base = tool.split('(').next().unwrap_or(tool);
-    if MCP_WRITE_PREFIXES.iter().any(|prefix| base.starts_with(prefix)) {
-        RiskTier::Dangerous
-    } else {
-        RiskTier::Moderate
-    }
-}
-
 /// Check if a command matches any prefix in the given list.
-fn matches_command_list(cmd: &str, list: &[&str]) -> bool {
+fn matches_command_list(cmd: &str, list: &[String]) -> bool {
     list.iter().any(|prefix| {
-        cmd == *prefix || cmd.starts_with(&format!("{prefix} ")) || cmd.starts_with(&format!("{prefix}:"))
+        cmd == prefix.as_str()
+            || cmd.starts_with(&format!("{prefix} "))
+            || cmd.starts_with(&format!("{prefix}:"))
     })
 }
 
-/// Determine recommendation for a rule given its risk tier and source.
-pub fn recommend(tier: RiskTier, source: &str, rule: &str) -> Recommendation {
-    // Permanently denied patterns
-    if let Some(cmd) = extract_bash_pattern(rule)
-        && matches_deny_list(cmd)
-    {
-        return Recommendation::Deny;
+/// Simple glob matching: `*` matches any sequence of non-empty chars.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.is_empty() {
+        return true;
     }
 
-    // Overly broad patterns
-    if is_overly_broad(rule) {
-        return Recommendation::Narrow;
+    let mut pos = 0;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !text[pos..].starts_with(part) {
+                return false;
+            }
+            pos += part.len();
+        } else {
+            match text[pos..].find(part) {
+                Some(found) => {
+                    if found == 0 {
+                        return false;
+                    }
+                    pos += found + part.len();
+                }
+                None => return false,
+            }
+        }
     }
-
-    match (tier, source) {
-        // Safe rules in local should be promoted to global
-        (RiskTier::Safe, "local") => Recommendation::Promote,
-        // Moderate rules in local - keep where they are
-        (RiskTier::Moderate, "local") => Recommendation::Keep,
-        // Dangerous rules in local - recommend removal
-        (RiskTier::Dangerous, "local") => Recommendation::Remove,
-        // Everything in global is already where it should be
-        (_, "global") => Recommendation::Keep,
-        _ => Recommendation::Keep,
-    }
-}
-
-/// Check if a rule pattern is overly broad (covers both safe and dangerous commands).
-fn is_overly_broad(rule: &str) -> bool {
-    // Bash(git:*) would match git status (safe) AND git push --force (dangerous)
-    let broad_patterns = ["Bash(git:*)", "Bash(docker:*)", "Bash(sudo:*)", "Bash(yes:*)"];
-    broad_patterns.contains(&rule)
+    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn rules() -> Rules {
+        Rules::default()
+    }
+
     // --- Deny list tests ---
 
     #[test]
     fn deny_rm() {
-        assert!(matches_deny_list("rm -rf /tmp"));
-        assert!(matches_deny_list("rm -r /tmp"));
-        assert!(matches_deny_list("rm /tmp/file"));
-        assert!(matches_deny_list("rm -f /tmp/file"));
+        let r = rules();
+        assert!(r.matches_deny_list("rm -rf /tmp"));
+        assert!(r.matches_deny_list("rm -r /tmp"));
+        assert!(r.matches_deny_list("rm /tmp/file"));
+        assert!(r.matches_deny_list("rm -f /tmp/file"));
     }
 
     #[test]
     fn deny_cd_and() {
-        assert!(matches_deny_list("cd && git status"));
-        assert!(matches_deny_list("cd /tmp && rm -rf ."));
+        let r = rules();
+        assert!(r.matches_deny_list("cd && git status"));
+        assert!(r.matches_deny_list("cd /tmp && rm -rf ."));
     }
 
     #[test]
     fn deny_git_tag_delete() {
-        assert!(matches_deny_list("git tag -d v1.0"));
+        let r = rules();
+        assert!(r.matches_deny_list("git tag -d v1.0"));
     }
 
     #[test]
     fn allow_safe_commands() {
-        assert!(!matches_deny_list("ls -la"));
-        assert!(!matches_deny_list("git status"));
-        assert!(!matches_deny_list("cargo build"));
+        let r = rules();
+        assert!(!r.matches_deny_list("ls -la"));
+        assert!(!r.matches_deny_list("git status"));
+        assert!(!r.matches_deny_list("cargo build"));
+    }
+
+    #[test]
+    fn replace_deny_list_removes_defaults() {
+        use crate::config::{Config, ListConfig, ListMode};
+        let mut config = Config::default();
+        config.deny_patterns = ListConfig {
+            mode: ListMode::Replace,
+            items: vec!["shutdown".to_string()],
+        };
+        let r = Rules::from_config(&config);
+        // rm should no longer be denied
+        assert!(!r.matches_deny_list("rm /tmp/file"));
+        // custom pattern should be denied
+        assert!(r.matches_deny_list("shutdown now"));
+    }
+
+    #[test]
+    fn extend_deny_list_adds_to_defaults() {
+        use crate::config::{Config, ListConfig, ListMode};
+        let mut config = Config::default();
+        config.deny_patterns = ListConfig {
+            mode: ListMode::Extend,
+            items: vec!["shutdown".to_string()],
+        };
+        let r = Rules::from_config(&config);
+        // Original patterns still apply
+        assert!(r.matches_deny_list("rm /tmp/file"));
+        // Custom pattern also applies
+        assert!(r.matches_deny_list("shutdown now"));
     }
 
     // --- Rule classification tests ---
 
     #[test]
     fn classify_safe_bash() {
-        assert_eq!(classify_rule("Bash(ls:*)"), RiskTier::Safe);
-        assert_eq!(classify_rule("Bash(git status:*)"), RiskTier::Safe);
-        assert_eq!(classify_rule("Bash(git diff:*)"), RiskTier::Safe);
-        assert_eq!(classify_rule("Bash(tree:*)"), RiskTier::Safe);
-        assert_eq!(classify_rule("Bash(cat:*)"), RiskTier::Safe);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(ls:*)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("Bash(git status:*)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("Bash(git diff:*)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("Bash(tree:*)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("Bash(cat:*)"), RiskTier::Safe);
     }
 
     #[test]
     fn classify_moderate_bash() {
-        assert_eq!(classify_rule("Bash(git commit:*)"), RiskTier::Moderate);
-        assert_eq!(classify_rule("Bash(git push:*)"), RiskTier::Moderate);
-        assert_eq!(classify_rule("Bash(cargo:*)"), RiskTier::Moderate);
-        assert_eq!(classify_rule("Bash(mkdir:*)"), RiskTier::Moderate);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(git commit:*)"), RiskTier::Moderate);
+        assert_eq!(r.classify_rule("Bash(git push:*)"), RiskTier::Moderate);
+        assert_eq!(r.classify_rule("Bash(cargo:*)"), RiskTier::Moderate);
+        assert_eq!(r.classify_rule("Bash(mkdir:*)"), RiskTier::Moderate);
     }
 
     #[test]
     fn classify_dangerous_bash() {
-        assert_eq!(classify_rule("Bash(sudo rm:*)"), RiskTier::Dangerous);
-        assert_eq!(classify_rule("Bash(sudo apt install:*)"), RiskTier::Dangerous);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(sudo rm:*)"), RiskTier::Dangerous);
+        assert_eq!(r.classify_rule("Bash(sudo apt install:*)"), RiskTier::Dangerous);
     }
 
     #[test]
     fn classify_file_tools() {
-        assert_eq!(classify_rule("Edit(src/**/*.rs)"), RiskTier::Moderate);
-        assert_eq!(classify_rule("Write(docs/**/*.md)"), RiskTier::Moderate);
-        assert_eq!(classify_rule("Read(**/*.yml)"), RiskTier::Safe);
+        let r = rules();
+        assert_eq!(r.classify_rule("Edit(src/**/*.rs)"), RiskTier::Moderate);
+        assert_eq!(r.classify_rule("Write(docs/**/*.md)"), RiskTier::Moderate);
+        assert_eq!(r.classify_rule("Read(**/*.yml)"), RiskTier::Safe);
     }
 
     #[test]
     fn classify_web_tools() {
-        assert_eq!(classify_rule("WebFetch(domain:docs.rs)"), RiskTier::Safe);
-        assert_eq!(classify_rule("WebSearch"), RiskTier::Safe);
+        let r = rules();
+        assert_eq!(r.classify_rule("WebFetch(domain:docs.rs)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("WebSearch"), RiskTier::Safe);
     }
 
     #[test]
     fn classify_skill() {
-        assert_eq!(classify_rule("Skill(rust-cli-coder)"), RiskTier::Safe);
+        let r = rules();
+        assert_eq!(r.classify_rule("Skill(rust-cli-coder)"), RiskTier::Safe);
     }
 
     #[test]
     fn classify_mcp_read() {
-        assert_eq!(classify_rule("mcp__atlassian__getJiraIssue"), RiskTier::Moderate);
+        let r = rules();
+        assert_eq!(r.classify_rule("mcp__atlassian__getJiraIssue"), RiskTier::Moderate);
     }
 
     #[test]
     fn classify_mcp_write() {
+        let r = rules();
         assert_eq!(
-            classify_rule("mcp__slack__conversations_add_message"),
+            r.classify_rule("mcp__slack__conversations_add_message"),
             RiskTier::Dangerous
         );
     }
@@ -535,20 +634,23 @@ mod tests {
 
     #[test]
     fn classify_input_bash_safe() {
-        assert_eq!(classify_tool_input("Bash", "ls -la"), RiskTier::Safe);
-        assert_eq!(classify_tool_input("Bash", "git log --oneline"), RiskTier::Safe);
+        let r = rules();
+        assert_eq!(r.classify_tool_input("Bash", "ls -la"), RiskTier::Safe);
+        assert_eq!(r.classify_tool_input("Bash", "git log --oneline"), RiskTier::Safe);
     }
 
     #[test]
     fn classify_input_bash_dangerous() {
-        assert_eq!(classify_tool_input("Bash", "sudo rm -rf /"), RiskTier::Dangerous);
-        assert_eq!(classify_tool_input("Bash", "rm -rf /tmp"), RiskTier::Dangerous);
+        let r = rules();
+        assert_eq!(r.classify_tool_input("Bash", "sudo rm -rf /"), RiskTier::Dangerous);
+        assert_eq!(r.classify_tool_input("Bash", "rm -rf /tmp"), RiskTier::Dangerous);
     }
 
     #[test]
     fn classify_input_force_push() {
+        let r = rules();
         assert_eq!(
-            classify_tool_input("Bash", "git push --force origin main"),
+            r.classify_tool_input("Bash", "git push --force origin main"),
             RiskTier::Dangerous
         );
     }
@@ -557,40 +659,39 @@ mod tests {
 
     #[test]
     fn recommend_promote_safe_local() {
-        assert_eq!(
-            recommend(RiskTier::Safe, "local", "Bash(ls:*)"),
-            Recommendation::Promote
-        );
+        let r = rules();
+        assert_eq!(r.recommend(RiskTier::Safe, "local", "Bash(ls:*)"), Recommendation::Promote);
     }
 
     #[test]
     fn recommend_keep_moderate_local() {
-        assert_eq!(
-            recommend(RiskTier::Moderate, "local", "Bash(cargo:*)"),
-            Recommendation::Keep
-        );
+        let r = rules();
+        assert_eq!(r.recommend(RiskTier::Moderate, "local", "Bash(cargo:*)"), Recommendation::Keep);
     }
 
     #[test]
     fn recommend_remove_dangerous_local() {
+        let r = rules();
         assert_eq!(
-            recommend(RiskTier::Dangerous, "local", "Bash(sudo rm:*)"),
+            r.recommend(RiskTier::Dangerous, "local", "Bash(sudo rm:*)"),
             Recommendation::Remove
         );
     }
 
     #[test]
     fn recommend_deny_pattern() {
+        let r = rules();
         assert_eq!(
-            recommend(RiskTier::Dangerous, "local", "Bash(rm -rf:*)"),
+            r.recommend(RiskTier::Dangerous, "local", "Bash(rm -rf:*)"),
             Recommendation::Deny
         );
     }
 
     #[test]
     fn recommend_narrow_broad() {
+        let r = rules();
         assert_eq!(
-            recommend(RiskTier::Moderate, "global", "Bash(git:*)"),
+            r.recommend(RiskTier::Moderate, "global", "Bash(git:*)"),
             Recommendation::Narrow
         );
     }
@@ -599,33 +700,36 @@ mod tests {
 
     #[test]
     fn broad_git_pattern() {
-        assert!(is_overly_broad("Bash(git:*)"));
+        let r = rules();
+        assert!(r.is_overly_broad("Bash(git:*)"));
     }
 
     #[test]
     fn not_broad_specific_git() {
-        assert!(!is_overly_broad("Bash(git status:*)"));
+        let r = rules();
+        assert!(!r.is_overly_broad("Bash(git status:*)"));
     }
 
     // --- Env var prefix tests ---
 
     #[test]
     fn env_var_prefix_is_dangerous() {
+        let r = rules();
         assert_eq!(
-            classify_rule("Bash(GH_TOKEN=\"$TOKEN\" gh pr view:*)"),
+            r.classify_rule("Bash(GH_TOKEN=\"$TOKEN\" gh pr view:*)"),
             RiskTier::Dangerous
         );
         assert_eq!(
-            classify_rule("Bash(GIT_SSH_COMMAND=\"ssh -i ~/.ssh/id\" git push:*)"),
+            r.classify_rule("Bash(GIT_SSH_COMMAND=\"ssh -i ~/.ssh/id\" git push:*)"),
             RiskTier::Dangerous
         );
-        assert_eq!(classify_rule("Bash(API_KEY=\"abc\" curl:*)"), RiskTier::Dangerous);
+        assert_eq!(r.classify_rule("Bash(API_KEY=\"abc\" curl:*)"), RiskTier::Dangerous);
     }
 
     #[test]
     fn lowercase_var_is_not_env_var() {
-        // lowercase assignments are not detected (conservative)
-        assert_ne!(classify_rule("Bash(foo=bar cmd:*)"), RiskTier::Dangerous);
+        let r = rules();
+        assert_ne!(r.classify_rule("Bash(foo=bar cmd:*)"), RiskTier::Dangerous);
     }
 
     #[test]
@@ -641,21 +745,43 @@ mod tests {
 
     #[test]
     fn git_dash_c_is_dangerous() {
-        assert_eq!(classify_rule("Bash(git -C /some/path push:*)"), RiskTier::Dangerous);
-        assert_eq!(classify_rule("Bash(git -C ~/repos/foo status:*)"), RiskTier::Dangerous);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(git -C /some/path push:*)"), RiskTier::Dangerous);
+        assert_eq!(r.classify_rule("Bash(git -C ~/repos/foo status:*)"), RiskTier::Dangerous);
     }
 
     #[test]
     fn git_without_dash_c_not_affected() {
-        assert_eq!(classify_rule("Bash(git status:*)"), RiskTier::Safe);
-        assert_eq!(classify_rule("Bash(git push:*)"), RiskTier::Moderate);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(git status:*)"), RiskTier::Safe);
+        assert_eq!(r.classify_rule("Bash(git push:*)"), RiskTier::Moderate);
     }
 
     // --- bash -c tests ---
 
     #[test]
     fn bash_dash_c_is_dangerous() {
-        assert_eq!(classify_rule("Bash(bash -c 'echo hi':*)"), RiskTier::Dangerous);
-        assert_eq!(classify_rule("Bash(bash -c:*)"), RiskTier::Dangerous);
+        let r = rules();
+        assert_eq!(r.classify_rule("Bash(bash -c 'echo hi':*)"), RiskTier::Dangerous);
+        assert_eq!(r.classify_rule("Bash(bash -c:*)"), RiskTier::Dangerous);
+    }
+
+    // --- subsumes tests ---
+
+    #[test]
+    fn subsumes_bash_prefix() {
+        assert!(subsumes("Bash(git:*)", "Bash(git status:*)"));
+        assert!(!subsumes("Bash(git status:*)", "Bash(git:*)"));
+    }
+
+    #[test]
+    fn subsumes_file_tool() {
+        assert!(subsumes("Edit(**)", "Edit(**/*.rs)"));
+        assert!(!subsumes("Edit(**/*.rs)", "Edit(**)"));
+    }
+
+    #[test]
+    fn subsumes_same_rule() {
+        assert!(!subsumes("Bash(git:*)", "Bash(git:*)"));
     }
 }

--- a/src/risk/tier.rs
+++ b/src/risk/tier.rs
@@ -93,8 +93,7 @@ const PERMANENT_DENY: &[&str] = &[
     "git tag -d",
     "git push * :refs/tags/",
     "git push * --delete * tag",
-    "rm -rf",
-    "rm -r ",
+    "rm ",
     "cd &&",
 ];
 
@@ -258,7 +257,6 @@ const MODERATE_BASH_COMMANDS: &[&str] = &[
     "pipx",
     "npm",
     "pnpm",
-    "rkvr rmrf",
     "gh pr create",
     "curl",
 ];
@@ -452,14 +450,11 @@ mod tests {
     // --- Deny list tests ---
 
     #[test]
-    fn deny_rm_rf() {
+    fn deny_rm() {
         assert!(matches_deny_list("rm -rf /tmp"));
-        assert!(matches_deny_list("rm -rf"));
-    }
-
-    #[test]
-    fn deny_rm_r() {
         assert!(matches_deny_list("rm -r /tmp"));
+        assert!(matches_deny_list("rm /tmp/file"));
+        assert!(matches_deny_list("rm -f /tmp/file"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove all hardcoded policy lists from Rust source code
- Introduce `ListConfig` (mode: `extend`|`replace` + `items`) in config.rs so every list has strong built-in defaults that users can override via `~/.config/claude-permit/claude-permit.yml`
- Introduce `Rules` struct built from `Config` at startup; all classification methods (`classify_rule`, `classify_tool_input`, `matches_deny_list`, `recommend`, etc.) are now methods on `Rules` rather than free functions
- Change `enforce-deny` default from `true` to `false` (observe-only by default; opt in to blocking)
- Thread `&Rules` through all command functions: log, audit, suggest, report, apply
- Update `claude-permit.yml` with full inline documentation of every configurable list and its built-in defaults

## Configurable lists (all default to `extend` mode)

| Config key | What it controls |
|---|---|
| `deny-patterns` | Commands blocked when `enforce-deny: true` |
| `safe-commands` | Bash commands classified as Safe |
| `moderate-commands` | Bash commands classified as Moderate |
| `mcp-write-tools` | MCP tools classified as Dangerous |
| `broad-patterns` | Patterns flagged as Narrow in audit |

## Motivation

Keegan discovered that the hardcoded `cd &&` deny pattern caused Claude to fall back to using `gh api --method PUT` to push file changes directly to GitHub, bypassing git entirely. Nothing should be baked into the binary — these should be configurable with strong defaults.

## Test plan

- [x] `cargo test` passes (116/116)
- [x] `deny-patterns: { mode: replace, items: [] }` disables all blocking
- [x] `deny-patterns: { items: ["shutdown"] }` adds to defaults
- [x] All existing classification and recommendation tests pass unchanged