### PR TITLE
Discover project-level .claude/settings.local.json from CWD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use claude_permit::cmd;
 use claude_permit::config::Config;
 use claude_permit::db::EventStore;
 use claude_permit::risk::Rules;
+use claude_permit::settings::discover_settings_local;
 use cli::{Cli, Command};
 
 fn setup_logging() -> Result<()> {
@@ -47,11 +48,8 @@ fn settings_path() -> PathBuf {
         .join("settings.json")
 }
 
-fn settings_local_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".claude")
-        .join("settings.local.json")
+fn cwd() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
 fn main() {
@@ -87,7 +85,7 @@ fn run() -> Result<()> {
         }
         Command::Check => {
             let db_path = EventStore::default_path()?;
-            let all_passed = cmd::run_check(&db_path, &settings_path(), &settings_local_path())?;
+            let all_passed = cmd::run_check(&db_path, &settings_path(), &discover_settings_local(&cwd()))?;
             if !all_passed {
                 std::process::exit(1);
             }
@@ -101,7 +99,7 @@ fn run() -> Result<()> {
             patterns,
         } => {
             let sp = settings.unwrap_or_else(settings_path);
-            let slp = settings_local.unwrap_or_else(settings_local_path);
+            let slp = settings_local.unwrap_or_else(|| discover_settings_local(&cwd()));
             let risk_filter = risk.and_then(|r| claude_permit::risk::RiskTier::from_str_opt(&r));
             cmd::run_audit(
                 &sp,
@@ -167,7 +165,7 @@ fn run() -> Result<()> {
             }
 
             let sp = settings.unwrap_or_else(settings_path);
-            let slp = settings_local.unwrap_or_else(settings_local_path);
+            let slp = settings_local.unwrap_or_else(|| discover_settings_local(&cwd()));
             let filter = claude_permit::cmd::apply::ApplyFilter {
                 promote: do_promote,
                 remove: do_remove,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,3 +1,3 @@
 mod parser;
 
-pub use parser::{PermissionList, PermissionRule, RuleSource, load_settings};
+pub use parser::{PermissionList, PermissionRule, RuleSource, discover_settings_local, load_settings};

--- a/src/settings/parser.rs
+++ b/src/settings/parser.rs
@@ -1,6 +1,6 @@
 use eyre::{Context, Result};
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Where a permission rule comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -105,6 +105,28 @@ pub fn load_settings(settings_path: &Path, settings_local_path: &Path) -> Result
     Ok(rules)
 }
 
+/// Walk up from `start_dir` looking for `.claude/settings.local.json`.
+/// Falls back to `~/.claude/settings.local.json` if no project-level file found.
+/// Existence check is intentional: discovery only activates for files that already
+/// exist, matching Claude Code's own discovery semantics.
+pub fn discover_settings_local(start_dir: &Path) -> PathBuf {
+    let mut dir = start_dir.to_path_buf();
+    loop {
+        let candidate = dir.join(".claude").join("settings.local.json");
+        if candidate.exists() {
+            return candidate;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent.to_path_buf(),
+            None => break,
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".claude")
+        .join("settings.local.json")
+}
+
 fn parse_settings_file(path: &Path) -> Result<SettingsFile> {
     let content = std::fs::read_to_string(path).context("Failed to read file")?;
     let settings: SettingsFile = serde_json::from_str(&content).context("Failed to parse JSON")?;
@@ -156,6 +178,32 @@ mod tests {
         let local = dir.path().join("also-nonexistent.json");
         let rules = load_settings(&global, &local).expect("load");
         assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn discover_finds_project_settings_local() {
+        let root = TempDir::new().expect("temp");
+        let claude_dir = root.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).expect("mkdir");
+        let expected = claude_dir.join("settings.local.json");
+        std::fs::write(&expected, r#"{"permissions":{}}"#).expect("write");
+
+        let subdir = root.path().join("project").join("src");
+        std::fs::create_dir_all(&subdir).expect("mkdir sub");
+
+        let found = discover_settings_local(&subdir);
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn discover_falls_back_to_home() {
+        let empty = TempDir::new().expect("temp");
+        let result = discover_settings_local(empty.path());
+        let expected = dirs::home_dir()
+            .expect("home dir")
+            .join(".claude")
+            .join("settings.local.json");
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/src/settings/parser.rs
+++ b/src/settings/parser.rs
@@ -107,13 +107,12 @@ pub fn load_settings(settings_path: &Path, settings_local_path: &Path) -> Result
 
 /// Walk up from `start_dir` looking for `.claude/settings.local.json`.
 /// Falls back to `~/.claude/settings.local.json` if no project-level file found.
-/// Existence check is intentional: discovery only activates for files that already
-/// exist, matching Claude Code's own discovery semantics.
+/// Only matches regular files so a directory named `settings.local.json` is skipped.
 pub fn discover_settings_local(start_dir: &Path) -> PathBuf {
     let mut dir = start_dir.to_path_buf();
     loop {
         let candidate = dir.join(".claude").join("settings.local.json");
-        if candidate.exists() {
+        if candidate.is_file() {
             return candidate;
         }
         match dir.parent() {
@@ -200,7 +199,7 @@ mod tests {
         let empty = TempDir::new().expect("temp");
         let result = discover_settings_local(empty.path());
         let expected = dirs::home_dir()
-            .expect("home dir")
+            .unwrap_or_else(|| PathBuf::from("."))
             .join(".claude")
             .join("settings.local.json");
         assert_eq!(result, expected);


### PR DESCRIPTION
Fixes #5

Walk up from CWD to find `.claude/settings.local.json`, matching Claude Code's own discovery behavior. Falls back to `~/.claude/settings.local.json` when no project-level file is found. `--settings-local` still overrides.

## Changes

- **`src/settings/parser.rs`**: Add `discover_settings_local(start_dir: &Path) -> PathBuf` — walks CWD ancestry, falls back to home
- **`src/settings/mod.rs`**: Re-export `discover_settings_local`
- **`src/main.rs`**: Wire `audit`, `apply`, `check` to use discovery instead of the hardcoded home path; remove unused `settings_local_path()`

## Tests

Two new unit tests in `src/settings/parser.rs`:
- `discover_finds_project_settings_local` — verifies walk-up from a subdirectory
- `discover_falls_back_to_home` — verifies fallback when no project file exists

All 118 tests pass.