### PR TITLE
feat(update): wire renew v0.1.2 self-update into claude-permit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -83,16 +89,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -126,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -148,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -175,6 +202,7 @@ dependencies = [
  "env_logger",
  "eyre",
  "log",
+ "renew",
  "rusqlite",
  "serde",
  "serde_json",
@@ -196,14 +224,58 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -223,7 +295,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -262,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -294,10 +366,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -367,6 +460,31 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -470,9 +588,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -480,7 +598,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -513,6 +634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,10 +671,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -595,6 +738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +787,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renew"
+version = "0.1.2"
+source = "git+https://github.com/tatari-tv/renew?tag=v0.1.2#4469886a9fb3e2826ea0d1b2693c37195e109a9d"
+dependencies = [
+ "chrono",
+ "clap",
+ "dirs",
+ "flate2",
+ "libc",
+ "log",
+ "self-replace",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tar",
+ "thiserror",
+ "ureq",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,7 +857,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -685,10 +908,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "self-replace"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -747,10 +981,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -777,6 +1028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +1042,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -797,7 +1065,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -807,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -831,6 +1099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +1121,47 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -964,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,12 +1357,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1127,6 +1524,22 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,17 @@ edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"
 description = "Manage Claude Code permission hygiene - log, audit, suggest, report"
+repository = "https://github.com/tatari-tv/claude-permit"
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 colored = "3.1.1"
 dirs = "6.0.0"
 env_logger = "0.11.10"
 eyre = "0.6.12"
 log = "0.4.29"
+renew = { git = "https://github.com/tatari-tv/renew", tag = "v0.1.2", version = "0.1.2" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ cargo install --git https://github.com/tatari-tv/claude-permit
 
 ---
 
+## Updating
+
+After the first install, subsequent upgrades go through the built-in `update` subcommand, backed by the [`renew`](https://github.com/tatari-tv/renew) library:
+
+```bash
+claude-permit update              # check whether a newer release is available (default action)
+claude-permit update check        # explicit check (exit 0 = current, 1 = update available, 2 = error)
+claude-permit update install      # download latest, verify sha256, atomic-replace this binary
+claude-permit update install --yes
+claude-permit update revert       # restore the previous version from the backup slot
+```
+
+`update install` writes a backup of the current binary to `~/.local/share/claude-permit/<install-path-hash>/backup/` before swapping. `revert` restores it. Only the most recent prior version is retained.
+
+When `claude-permit` is invoked interactively (any subcommand other than `log`/`check`) and a newer release exists, a one-line stderr notice is printed. The `log` hook hot path is exempt from this entirely - no cache reads, no network probes.
+
+**Caveats:**
+
+- **Source installs:** users who installed via `cargo install --git ...` or `cargo install --path .` should keep updating that way. `claude-permit update install` swaps the binary in place but does not refresh cargo's `~/.cargo/.crates.toml` registry.
+- **Do not pass an explicit `VERSION`** to `update install`. Renew v0.1.2 has a known bug where `install_version` queries `/releases/latest` and rejects mismatches, so `claude-permit update install 0.1.5` fails unless `0.1.5` is also the latest tag. Omit the positional argument to install latest.
+
+---
+
 ## Problem
 
 Claude Code accumulates permission rules over time through one-off approvals during sessions. These rules live in `settings.json` and `settings.local.json` with no built-in way to review, prune, or promote them. After a few weeks of use, you end up with hundreds of rules - some dangerously broad, some stale, some duplicated - and no feedback loop between your permission decisions and your permission policy.

--- a/docs/design/2026-05-01-renew-self-update.md
+++ b/docs/design/2026-05-01-renew-self-update.md
@@ -1,0 +1,270 @@
+# Design Document: Self-Update via `renew`
+
+**Author:** Scott Idler
+**Date:** 2026-05-01
+**Status:** Implemented (pending Phase 4 shakedown against post-bump release)
+**Review Passes Completed:** 5/5
+
+## Summary
+
+Wire the `renew` library (v0.1.2) into `claude-permit` so users can discover and install new releases from inside the tool itself. Add an `update` subcommand and a passive "newer version available" stderr notice on interactive invocations. The `log` hook hot path is exempted from all renew machinery to preserve PreToolUse latency.
+
+## Problem Statement
+
+### Background
+
+`claude-permit` ships via two paths today:
+
+1. `install.sh` -- clones the repo and runs `cargo install --path .`.
+2. Tagged GitHub releases with prebuilt tarballs for `linux-amd64`, `linux-arm64`, `macos-x86_64`, `macos-arm64` (produced by `.github/workflows/release-and-publish.yml`).
+
+There is no in-tool mechanism to (a) tell the user a newer release exists or (b) install it. Users must re-run `install.sh` or download a tarball by hand.
+
+This is one of three Tatari CLIs (`ccu`, `claude-permit`, `persona-cli`) shipped in the same week (2026-04-03) with a roughly weekly release cadence. The friction of "go re-clone and rebuild" multiplies across users x tools x weeks.
+
+### Problem
+
+Users have no in-tool path to discover or install `claude-permit` updates. We should adopt the standard Tatari CLI self-update mechanism: the `renew` library.
+
+### Goals
+
+- Add a `claude-permit update` subcommand that exposes `check`, `install`, and `revert`.
+- Print a passive stderr notice when a newer version is available and stderr is a TTY.
+- Do not regress `claude-permit log` or `claude-permit check` hot-path latency, and do not pollute `log` stdout.
+- Reuse the existing release workflow (which already conforms to the renew producer contract).
+
+### Non-Goals
+
+- **No automatic install.** Notice on interactive runs only; install is opt-in via `update install`.
+- **No background refresh daemon.** Cache lives at `dirs::cache_dir()/claude-permit/` and refreshes on demand.
+- **No release-workflow changes.** The current workflow already emits compliant artifacts; verifying is the work, not rebuilding.
+- **No replacement of `install.sh`.** First-time install still goes through `install.sh` or `cargo install --path .`. `renew` is for subsequent upgrades.
+
+## Proposed Solution
+
+### Overview
+
+Add `renew = { git = "https://github.com/tatari-tv/renew", tag = "v0.1.2" }` to `Cargo.toml`, set `[package].repository`, add an `Update(UpdateCmd)` variant to the CLI enum, and wire the `Renew` instance into `main.rs` after the hot-path gate (which exempts `Log` and `Check`).
+
+### Architecture
+
+```rust
+fn run() -> Result<()> {
+    setup_logging()?;
+    let cli = Cli::parse();
+
+    // Three classes of command:
+    //   - Hot path (Log, Check): never construct renew.
+    //   - Update: construct renew (we'll need it for dispatch) but skip the
+    //     passive notice -- the subcommand prints its own version-availability
+    //     output, and running notify here would duplicate it.
+    //   - Everything else: construct + notify.
+    let renew_handle = match &cli.command {
+        Command::Log | Command::Check => None,
+        Command::Update(_) => Some(renew::renew!().expect("repository metadata")),
+        _ => {
+            let r = renew::renew!().expect("repository metadata");
+            r.notify_if_outdated();   // stderr-TTY-gated; may hit GitHub API on stale cache
+            Some(r)
+        }
+    };
+
+    match cli.command {
+        Command::Log => { /* existing log arm, unchanged */ }
+        Command::Check => { /* existing check arm, unchanged */ }
+        Command::Update(cmd) => {
+            let r = renew_handle.expect("renew constructed for non-hot-path commands");
+            std::process::exit(cmd.run(&r));
+        }
+        // all other existing arms unchanged
+    }
+
+    Ok(())
+}
+```
+
+The first match (`match &cli.command`) borrows `cli.command` to peek at the variant; the second match (`match cli.command`) consumes it. This pattern compiles cleanly because the borrow is released at the end of the first match's scope before the second match takes ownership.
+
+**The hot-path gate is the central design decision** and departs from the renew README quickstart (which calls `notify_if_outdated()` before `Cli::parse()`). Two reasons:
+
+1. **`notify_if_outdated()` is not free.** Reading `renew/src/renew.rs`: the function checks `std::io::stderr().is_terminal()`, then calls `check_latest()`, which honors the cache but performs a synchronous blocking GitHub API request (default network timeout 5s) whenever the cache is absent or older than `cache_ttl` (default 24 hours, per `DEFAULT_CACHE_TTL_SECS` at `renew/src/renew.rs:15`). Hot-path commands cannot afford a potential 5s blocking call.
+2. **`claude-permit log`** runs as a `PreToolUse` hook on every Claude Code tool use; **`claude-permit check`** is invoked from health-check scripts (e.g., from `~/.claude/`) and may have a TTY stderr. Both should bypass renew entirely so neither pays cache IO nor risks an outbound network probe.
+
+The stderr-TTY gate inside `notify_if_outdated()` is correct for a release-mode hook (Claude Code pipes hook stderr), but it is fragile in development -- a user debugging a hook with `2>/dev/tty` would unwittingly trigger a network probe inside the hot path. The explicit gate makes the safety invariant load-bearing in this repo, not in renew.
+
+### Data Model
+
+No new types defined in this repo. Public surface used from `renew`:
+
+- `renew::Renew` -- handle, constructed via the `renew::renew!()` macro.
+- `renew::UpdateCmd` -- `clap::Args` struct exposing `check` / `install` / `revert`.
+- `renew::Result` / `renew::Error` -- for any direct calls (none planned beyond `UpdateCmd::run`).
+
+The `renew!()` macro expands to `Renew::new(env!("CARGO_PKG_REPOSITORY"), env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))`. It requires `[package].repository` to be set in `Cargo.toml`.
+
+### API Design
+
+New CLI subcommand. The full surface comes from `renew::UpdateCmd` (a `clap::Args`) -- we are inheriting its flags, not redefining them. Exit code semantics below come from the renew README's exit-code table; we treat that as authoritative for the consumer:
+
+```
+claude-permit update                                   # default = check (no args)
+claude-permit update check  [--refresh]                # exit 0 = up to date, 1 = update available, 2 = error
+claude-permit update install [VERSION] [--yes] [--force] [--refresh] [--install-path PATH]
+                                                       # exit 0 = installed or aborted by user, 2 = error
+claude-permit update revert  [--yes] [--install-path PATH]
+                                                       # exit 0 = reverted or aborted by user,  2 = error
+```
+
+Behavior notes:
+
+- `install` downloads the platform tarball, verifies the sha256 sidecar, and atomic-replaces the running binary. A backup of the current binary is written to `dirs::data_local_dir()/claude-permit/<install-path-hash>/backup/` before swap.
+- `revert` restores from that backup. There is exactly one backup slot per install path, so two consecutive `install` calls overwrite the first backup; revert can only restore the most recent prior version, not arbitrary history.
+- Confirmation prompts default to `N`. If stdin is not a TTY and `--yes` was not passed, the prompt errors with `PromptRequiredButStdinNotTty` and exits 2 -- this is the documented behavior we want for piped invocations.
+- A user typing `N` (or anything not `y` / `yes`) at the prompt exits cleanly with code 0.
+- **Known bug -- positional `VERSION`:** `claude-permit update install 0.1.5` will fail unless `0.1.5` is also the latest tag. Internally `Renew::install_version` queries `/releases/latest` and rejects mismatches. This bug is in renew v0.1.2 and is upstream (not in our control). Workaround: omit the positional to install latest. We document this in the user-facing notes (Phase 5) but cannot remove the flag without forking the type.
+
+### Implementation Plan
+
+#### Phase 1: Cargo metadata
+**Model:** sonnet
+
+- Add `repository = "https://github.com/tatari-tv/claude-permit"` to `[package]` in `Cargo.toml`.
+- Add `renew = { git = "https://github.com/tatari-tv/renew", tag = "v0.1.2" }` to `[dependencies]` (use `cargo add` so the lockfile updates cleanly).
+- Run `cargo check` to confirm the dep resolves and the macro can read `CARGO_PKG_REPOSITORY` at compile time.
+
+#### Phase 2: CLI wiring
+**Model:** sonnet
+
+- Add `Update(renew::UpdateCmd)` variant to `Command` in `src/cli.rs`. Include a one-line doc comment so `--help` lists it.
+- In `src/main.rs::run()`, restructure as shown in [Architecture](#architecture):
+  - Move `Command::Log` and `Command::Check` arms into an early-return block before `renew!()` is called.
+  - After the gate, construct `let r = renew::renew!().expect("repository metadata");` and call `r.notify_if_outdated();`.
+  - Dispatch `Command::Update(cmd) => std::process::exit(cmd.run(&r))`.
+- Keep all other subcommand arms unchanged.
+- Verify the existing `main()` `is_log` special-case (which prints `{}` and swallows errors when `log` fails) still triggers correctly by checking `std::env::args().nth(1) == Some("log")`. `Update` errors must NOT route through this path -- they go through the standard `eprintln + exit(1)` flow.
+
+#### Phase 3: Verify release workflow
+**Model:** sonnet
+
+- Re-read `.github/workflows/release-and-publish.yml` and confirm:
+  - Tarball name matches `claude-permit-<tag>-<platform>.tar.gz` for `linux-amd64`, `linux-arm64`, `macos-x86_64`, `macos-arm64`.
+  - Sidecar name matches `<tarball>.sha256` and contains the lowercase-hex sha256 in the first 64 chars.
+  - Tarball contains exactly one regular file (the `claude-permit` binary) -- check the `tar -czvf ... -C artifacts claude-permit` invocation.
+  - Tag pattern is `v*` (annotated, on `main`).
+- No expected changes -- this phase produces a single line in the PR description: "release workflow verified compliant, no changes."
+
+#### Phase 4: Shakedown the new binary
+**Model:** sonnet
+
+Cut a release with phases 1+2, install it on a real machine, then run `/cli-shakedown` against the freshly built binary. The skill systematically exercises every command and flag and produces a field guide of tested examples; that's the broad coverage. Beyond what shakedown discovers automatically, three integration-flavored checks must be exercised explicitly because they touch state the binary alone can't observe (the live release, the backup directory, and the hook hot path):
+
+- `update install --yes` against an older binary, then `claude-permit --version` reflects the new tag and `claude-permit log < hook-fixture.json 2>/dev/null` still emits valid JSON. This is the post-replace end-to-end check -- catches the case where install "succeeds" but the new binary segfaults or is the wrong platform.
+- `update revert --yes` after the above, then `claude-permit --version` confirms the previous tag is restored.
+- `claude-permit log < hook-fixture.json 2>/dev/null` -- stdout is exactly the expected JSON, no `notify_if_outdated` notice leaks in. This is the hot-path-silence invariant; shakedown won't catch it on its own because shakedown runs interactively (stderr is a TTY) where the notice IS expected.
+
+#### Phase 5: User-facing docs
+**Model:** sonnet
+
+- Add an "Updating" section to `README.md` pointing at `claude-permit update install`. Include the `cargo install --path .` caveat for source installs and the "do not pass an explicit VERSION" note (positional version arg has the renew v0.1.2 install_version bug).
+- Update `install.sh` comment header noting that first install still uses the script, but subsequent updates go through `claude-permit update install`.
+- Update `cli.rs` `after_help` to mention `claude-permit update --help`.
+
+## Alternatives Considered
+
+### Alternative 1: Reinstall via `install.sh` only
+
+- **Description:** Document the existing path; print a stderr message at startup telling users to re-run `install.sh`.
+- **Pros:** Zero new dependencies; nothing to maintain.
+- **Cons:** Requires a clean clone + cargo build for every update; no version-check mechanism; no atomic swap or revert; bad UX at three CLIs x weekly cadence.
+- **Why not chosen:** The whole point of standardizing on `renew` across all three Tatari CLIs is to stop paying this UX tax.
+
+### Alternative 2: Hand-rolled self-update
+
+- **Description:** Custom `claude-permit update` command that calls the GitHub API, downloads the tarball, verifies sha256, swaps the binary.
+- **Pros:** No new external dep; tailor behavior precisely.
+- **Cons:** Reinvents `renew`. Error-prone bits (atomic replace, backup/revert, sha verification, redirect-auth stripping) are exactly what `renew` already solves. Three CLIs each maintaining their own copy is worse.
+- **Why not chosen:** Maintenance cost dwarfs the dependency cost.
+
+### Alternative 3: Call `notify_if_outdated()` before parsing args (per renew README)
+
+- **Description:** Match the renew quickstart pattern verbatim -- run notify before `Cli::parse()`.
+- **Pros:** One fewer code branch; matches the README example exactly.
+- **Cons:** On the `claude-permit log` hook hot path, every PreToolUse invocation would do at minimum a TTY check on stderr; if a developer ever runs the hook with `2>/dev/tty` for debugging, the notice path would do a cache read AND, if the cache is stale, a synchronous GitHub API round-trip on every tool use.
+- **Why not chosen:** Hook-path latency and reliability are non-negotiable. The match-on-`Command` gate adds ~5 lines of code to make the safety property load-bearing in this repo, not contingent on internal renew behavior.
+
+## Technical Considerations
+
+### Dependencies
+
+- **External:** `renew` v0.1.2 (git dep, pinned to annotated tag, NOT a branch).
+- **Internal:** none new.
+- **Transitive (added by renew):** `flate2`, `tar`, `sha2`, `self-replace`, `semver`, `ureq` with rustls. All standard, no surprises.
+- **No `tracing-log` bridge required:** claude-permit uses `log` + `env_logger` (per `Cargo.toml`), and renew also emits `log` records, so they share a backend. The bridge is only needed for consumers using `tracing`.
+
+### Performance
+
+- **Hot path (`Command::Log`, `Command::Check`):** unchanged. `renew!()` is never constructed and `notify_if_outdated()` is never called.
+- **`Command::Update`:** `renew!()` is constructed but `notify_if_outdated()` is skipped (the subcommand has its own output; running notify would print version-availability twice, once to stderr and once to stdout via `cmd.run`).
+- **Interactive paths (`audit`, `suggest`, `report`, `install`, `apply`):** `notify_if_outdated()` runs.
+  - **Cache hit** (entry exists and is younger than `cache_ttl`, default 24 hours per `renew/src/renew.rs:15`): one cache-file read at `dirs::cache_dir()/claude-permit/check.yml`. ~ms.
+  - **Cache miss / stale** AND stderr is a TTY: synchronous blocking GitHub API request inside `check_latest()`, network timeout 5s. With the 24h default TTL, a given machine hits this at most once per day -- but on a slow network or during a GitHub incident, that one invocation per day blocks for up to 5s before the user's actual command starts. Lock file at `dirs::cache_dir()/claude-permit/check.lock` serializes concurrent processes; the loser falls back to whatever cache exists.
+  - **Cache miss / stale** AND stderr is NOT a TTY: function returns immediately before any IO -- the TTY gate is the first thing checked.
+- `update check` (explicit) always honors the cache; `update install` does the network call regardless.
+
+### Security
+
+- Auth: anonymous works for public repos; `claude-permit` is public, so no token required by default. If made private, set `GH_TOKEN` or `GITHUB_TOKEN` in env.
+- The auth header is stripped on the 302 redirect to S3 by `renew` itself (`RedirectAuthHeaders::Never`); no token leakage to presigned URLs.
+- All downloads are sha256-verified against the sidecar before replacement.
+- Self-replace is atomic; failed verification or download leaves the existing binary intact.
+
+### Testing Strategy
+
+- No new unit tests in `claude-permit` -- the `renew` library has its own coverage of cache, network, sha verification, and self-replace.
+- `/cli-shakedown` covers broad command/flag exercise on the new binary.
+- Phase 4 explicit checks cover the three things shakedown can't: post-replace version-reflects-new-tag, revert restores prior tag, and hot-path silence on the `log` invocation (where stderr is NOT a TTY).
+- Optional follow-up (not blocking): add an integration test in `tests/` that invokes `claude-permit log < fixture.json`, asserts exit code 0, asserts stdout parses as JSON, and asserts stdout has no trailing bytes after the JSON. Such a test would also catch any future regression where `notify_if_outdated()` silently leaks bytes into stdout.
+
+### Rollout Plan
+
+1. Implement phases 1-3 on a feature branch.
+2. Open a PR per `tatari-tv/*` branch-protection convention (verify live state with `gh api repos/tatari-tv/claude-permit/branches/main/protection`; if 404, direct push is acceptable, but PR is preferred for the visibility of this change).
+3. After merge, on `main`: `bump` (patch) then push the tag. The tag triggers `release-and-publish.yml`.
+4. Phase 4 manual smoke runs against the published release on lappy + desk.
+5. Phase 5 docs and `#clipboard` announcement.
+6. **Soak constraint:** do not bump renew's pinned tag (e.g., to v0.1.3) inside `claude-permit` until `ccu` (the canary consumer) has run for at least a week on the new tag without issue. Cross-consumer renew bumps go consumer-by-consumer, never as a sweep, so a regression in renew doesn't take down all three Tatari CLIs simultaneously.
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `notify_if_outdated()` leaks output into `claude-permit log` stdout, breaking the hook | Low | High | Hot-path gate (`Log` bypasses renew entirely); phase 4 verifies stdout cleanliness |
+| Hot-path latency regression on `log` or `check` | Low | High | Hot-path gate; even cache-only IO is avoided. Critical because `notify_if_outdated()` is NOT IO-free on stale cache |
+| Network probe on hook hot path during user debugging (`2>/dev/tty`) | Low | High | Hot-path gate -- the stderr-TTY check inside renew is bypassed entirely for `Log` |
+| macOS Gatekeeper blocks atomic self-replace on unsigned binaries | Med | Med | renew v0.1.2 backs up before replacing; `revert` restores; users can fall back to `install.sh` |
+| User runs `cargo install --path .` then later `update install` -- cargo's `~/.cargo/.crates.toml` registry no longer reflects the installed binary version | High | Low | Document in README: users who installed from source should continue to update via `cargo install --path .` from the latest tag, not via `claude-permit update install` |
+| `Renew::install_version` known bug (only accepts version equal to `latest`) | N/A | N/A | Use `UpdateCmd::Install { version: None, .. }` via the dispatch only; never call `install_version` directly |
+| Network failure during `update check` blocks interactive flow | Low | Low | `check` returns exit 2 on error; users can retry; cache is stale-tolerant |
+| Concurrent `claude-permit` processes refresh cache simultaneously | Low | Low | renew uses an exclusive lock at `dirs::cache_dir()/claude-permit/check.lock`; loser falls through to existing cache |
+| User passes positional `VERSION` to `update install`, hits the renew v0.1.2 install_version bug | Med | Low | Document in README + `--help`; pinning renew to a tag means we'll get the upstream fix when it lands and can bump deliberately after canary soak |
+| `claude-permit update install --yes` running concurrently with `claude-permit log` (active hook on a Claude Code session) | Med | Low | `self-replace` is designed for this -- the running process keeps its file handle; new invocations get the new binary. No coordination needed |
+
+## Resolved During Review
+
+- **`notify_if_outdated()` IO behavior** (Pass 2): NOT IO-free on stale cache. Confirmed by reading `renew/src/renew.rs` lines 15, 116-134 (`check_latest`), and 361-377 (`notify_if_outdated`). It performs a synchronous blocking GitHub API request whenever the cache is older than `cache_ttl` (default 24h, `DEFAULT_CACHE_TTL_SECS`) AND stderr is a TTY. Resolution: hot-path gate covers `Command::Log` and `Command::Check`.
+- **Duplicate version-available output on `update check`** (Architect review): `notify_if_outdated()` printing to stderr and `UpdateCmd::Check` printing to stdout would render the same message twice on `claude-permit update check` with stale cache. Resolution: `Command::Update(_)` constructs `Renew` (needed for dispatch) but skips `notify_if_outdated()`; the subcommand owns its own output.
+- **Cache TTL was 24h, not 1h** (Architect review, verified at `renew/src/renew.rs:15`): doc previously claimed default was 1h. Corrected throughout. The 24h default makes GitHub rate-limit concerns essentially moot at any realistic Tatari user count.
+- **Synchronous network I/O at startup is acceptable** (Architect review, consensus after pushback): `notify_if_outdated()` can block up to 5s on cache miss + slow network. Architect's initial position was "never block on self-update." After pushback citing (a) industry-standard pattern (`gh`, `npm`, `brew`, `cargo`, `rustup` all do this), (b) the verified 24h TTL bounding worst case to 1x 5s/day per machine, (c) renew v0.1.2 has no async path so backgrounding would require forking the library, and (d) a `--no-update-check` flag can be added reactively if reports come in -- consensus was to document the trade-off honestly in the Performance section and proceed. If real-world reports surface, the right fix lives in renew (e.g., a `RENEW_NO_UPDATE_CHECK=1` opt-out), not in claude-permit.
+
+## Open Questions
+
+- [ ] **`update install` from `~/.cargo/bin/claude-permit`:** users who installed via `cargo install --path .` will silently desync cargo's `~/.cargo/.crates.toml` registry if they then run `update install`. Current mitigation is documentation only. Should we add a path-prefix check (`current_exe()` contains `.cargo/bin`) and either (a) refuse with a helpful error, or (b) print a louder warning before invoking renew's prompt? Option (a) is paternalistic and the heuristic is brittle (CARGO_INSTALL_ROOT, symlinks, custom layouts). Option (b) is non-trivial because the prompt is owned by `UpdateCmd::Install`, not us -- we'd need to print our own warning before calling `cmd.run(&r)`. Defer until smoke testing reveals real-world impact; if no Tatari user reports the issue, leave as docs-only.
+
+## References
+
+- `renew` README: https://github.com/tatari-tv/renew
+- `renew` v0.1.2 tag: https://github.com/tatari-tv/renew/releases/tag/v0.1.2
+- `renew/src/renew.rs` -- `check_latest` (lines 116-134) and `notify_if_outdated` (lines 361-377), the implementations behind the IO-behavior decision
+- `renew/src/cmd.rs` -- `UpdateCmd` definition, including the inherited `--refresh` / `--force` / positional `VERSION` flags
+- claude-permit release workflow: `.github/workflows/release-and-publish.yml`
+- Sibling design docs: `2026-03-24-claude-permit.md` (initial scaffold), `2026-03-24-apply.md` (apply subcommand)

--- a/docs/design/2026-05-01-renew-self-update.md
+++ b/docs/design/2026-05-01-renew-self-update.md
@@ -15,7 +15,7 @@ Wire the `renew` library (v0.1.2) into `claude-permit` so users can discover and
 
 `claude-permit` ships via two paths today:
 
-1. `install.sh` -- clones the repo and runs `cargo install --path .`.
+1. `install.sh` -- downloads the latest release tarball and installs the binary to `INSTALL_DIR` (default `~/.local/bin`).
 2. Tagged GitHub releases with prebuilt tarballs for `linux-amd64`, `linux-arm64`, `macos-x86_64`, `macos-arm64` (produced by `.github/workflows/release-and-publish.yml`).
 
 There is no in-tool mechanism to (a) tell the user a newer release exists or (b) install it. Users must re-run `install.sh` or download a tarball by hand.

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# First-time installer for claude-permit. Downloads the latest tarball, verifies
+# nothing, and drops the binary into INSTALL_DIR. Subsequent upgrades should go
+# through the built-in self-updater: `claude-permit update install`.
 set -euo pipefail
 
 REPO="tatari-tv/claude-permit"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,9 @@ pub enum Command {
         yes: bool,
     },
 
+    /// Check for and install updates from GitHub releases
+    Update(renew::UpdateCmd),
+
     /// Apply audit recommendations to settings files
     Apply {
         /// Apply "promote" recommendations (move safe local rules to global)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
     name = "claude-permit",
     about = "Manage Claude Code permission hygiene",
     version = env!("GIT_DESCRIBE"),
-    after_help = "Logs are written to: ~/.local/share/claude-permit/logs/claude-permit.log"
+    after_help = "Logs are written to: ~/.local/share/claude-permit/logs/claude-permit.log\n\nSelf-update: see `claude-permit update --help`."
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,16 @@ fn run() -> Result<()> {
     let config = Config::load(None).unwrap_or_default();
     let rules = Rules::from_config(&config);
 
+    let renew_handle = match &cli.command {
+        Command::Log | Command::Check => None,
+        Command::Update(_) => Some(renew::renew!().expect("repository metadata")),
+        _ => {
+            let r = renew::renew!().expect("repository metadata");
+            r.notify_if_outdated();
+            Some(r)
+        }
+    };
+
     match cli.command {
         Command::Log => {
             let db_path = EventStore::default_path()?;
@@ -143,6 +153,10 @@ fn run() -> Result<()> {
         Command::Install { settings, yes } => {
             let sp = settings.unwrap_or_else(settings_path);
             cmd::run_install(&sp, yes)?;
+        }
+        Command::Update(cmd) => {
+            let r = renew_handle.expect("renew constructed for non-hot-path commands");
+            std::process::exit(cmd.run(&r));
         }
         Command::Apply {
             promote,


### PR DESCRIPTION
## Summary

- Wires `renew` v0.1.2 into `claude-permit` as a new `update` subcommand exposing `check` / `install` / `revert`, plus a passive stderr "newer version available" notice on interactive runs.
- The hot-path gate (`Command::Log` and `Command::Check`) is the central design decision: those arms never construct `Renew` and never call `notify_if_outdated()`. `notify_if_outdated()` is NOT IO-free on stale cache — it does a synchronous blocking GitHub API request on a 24h cache TTL — so the hook hot path cannot afford it.
- Includes a pre-existing test fix (`field_reassign_with_default` clippy lint) that was blocking `otto ci` on a fresh local toolchain. Pulled out as its own commit for reviewer clarity.

## Phases

- **Phase 1** Cargo metadata: `repository =` + `renew` git dep pinned to tag `v0.1.2`. Bumped `clap` to 4.6.1 (renew minimum).
- **Phase 2** CLI wiring: `Update(renew::UpdateCmd)` variant, restructured `run()` with the hot-path gate.
- **Phase 3** Release workflow: re-read `.github/workflows/release-and-publish.yml`, confirmed compliance with the renew producer contract (tarball name, sidecar, single-file archive, `v*` tag pattern). No changes.
- **Phase 5** User-facing docs: README "Updating" section, `install.sh` header comment, `cli.rs` `after_help`. Design doc landed alongside.

## Phase 4 (post-merge)

Phase 4 (shakedown) is intentionally not included in this PR. It requires a published release tag to test against, which only exists after this merges and a `bump` cuts the next tag. After the workflow publishes the release, run:

- `/cli-shakedown` against the freshly built binary
- `update install --yes` from an older version, then `claude-permit --version` should reflect the new tag and `claude-permit log < hook-fixture.json 2>/dev/null` must still emit valid JSON
- `update revert --yes`, then confirm previous tag is restored
- `claude-permit log < hook-fixture.json 2>/dev/null` — hot-path-silence invariant: no `notify_if_outdated` notice leaks into stdout

## Test plan

- [x] `otto ci` green
- [x] `cargo run -- --help` shows `update` subcommand
- [x] `cargo run -- update --help` exposes `check`/`install`/`revert` from `renew::UpdateCmd`
- [x] Hot path silent on stderr: `cargo run -- check 2>/tmp/check-stderr` produces empty stderr
- [x] Hot path silent on stderr: hook-style `claude-permit log` invocation produces empty stderr and `{}` on stdout
- [ ] Phase 4 shakedown after release publishes (post-merge)

Design doc: `docs/design/2026-05-01-renew-self-update.md`